### PR TITLE
fix(renderSideScore): show tiebreak points for match-tiebreak final sets

### DIFF
--- a/src/components/renderStructure/__tests__/renderSideScore.test.ts
+++ b/src/components/renderStructure/__tests__/renderSideScore.test.ts
@@ -106,6 +106,28 @@ describe('setScore', () => {
     // Should display tiebreak score directly
     expect(el.innerHTML).toContain('10');
   });
+
+  it('handles match-tiebreak final set normalised by the engine (tiebreakSet flag set, game score collapsed to 1/0)', () => {
+    // For SET3-S:6/TB7-F:TB10, the engine normalises the final-set match tiebreak to
+    // side1Score/side2Score 1/0 with the actual points carried on side*TiebreakScore and
+    // `tiebreakSet: true` on the set. The renderer must honour the flag and show the
+    // tiebreak points; otherwise the draw cell collapses to 1/0 and the points disappear.
+    const set: SetScore = {
+      setNumber: 3,
+      side1Score: 1,
+      side2Score: 0,
+      side1TiebreakScore: 10,
+      side2TiebreakScore: 7,
+      tiebreakSet: true,
+      winningSide: 1
+    };
+    const side1El = setScore({ set, sideNumber: 1 });
+    expect(side1El.innerHTML).toContain('10');
+    expect(side1El.innerHTML).not.toMatch(/>1</);
+    const side2El = setScore({ set, sideNumber: 2 });
+    expect(side2El.innerHTML).toContain('7');
+    expect(side2El.innerHTML).not.toMatch(/>0</);
+  });
 });
 
 describe('renderSideScore', () => {
@@ -195,6 +217,41 @@ describe('renderSideScore', () => {
     });
     expect(el).toBeInstanceOf(HTMLElement);
     expect(el.querySelectorAll('.tmx-st').length).toBe(0);
+  });
+
+  it('renders tiebreak points from scoreStringSide bracket token when the set lacks side*TiebreakScore', () => {
+    // Reproduces the SET3-S:6/TB7-F:TB10 case: factory persists the final-set match tiebreak
+    // with side1Score:1/side2Score:0/tiebreakSet:true and parks the actual points (e.g. "[10-7]")
+    // only in scoreStringSide1/2. The renderer must recover the TB points from those strings.
+    const sets: SetScore[] = [
+      { setNumber: 1, side1Score: 7, side2Score: 5, winningSide: 1 },
+      { setNumber: 2, side1Score: 6, side2Score: 7, side1TiebreakScore: 4, side2TiebreakScore: 7, winningSide: 2 },
+      { setNumber: 3, side1Score: 1, side2Score: 0, tiebreakSet: true, winningSide: 1 }
+    ];
+    const matchUp = {
+      matchUpId: 'mu-tb',
+      matchUpType: 'SINGLES',
+      structureId: 'struct-1',
+      score: {
+        sets,
+        scoreStringSide1: '7-5 6-7(4) [10-7]',
+        scoreStringSide2: '5-7 7-6(4) [7-10]'
+      },
+      sides: [
+        { sideNumber: 1, participant: { participantId: 'p1', participantName: 'Player 1' } },
+        { sideNumber: 2, participant: { participantId: 'p2', participantName: 'Player 2' } }
+      ]
+    } as MatchUp;
+
+    const side1El = renderSideScore({ matchUp, sideNumber: 1 });
+    const side1SetEls = side1El.querySelectorAll('.tmx-st');
+    expect(side1SetEls[2].innerHTML).toContain('10');
+    expect(side1SetEls[2].innerHTML).not.toMatch(/>1</);
+
+    const side2El = renderSideScore({ matchUp, sideNumber: 2 });
+    const side2SetEls = side2El.querySelectorAll('.tmx-st');
+    expect(side2SetEls[2].innerHTML).toContain('7');
+    expect(side2SetEls[2].innerHTML).not.toMatch(/>0</);
   });
 
   it('applies participantHeight when provided', () => {

--- a/src/components/renderStructure/renderSideScore.ts
+++ b/src/components/renderStructure/renderSideScore.ts
@@ -19,10 +19,14 @@ export function setScore({
   const isWinningSide = sideNumber === set?.winningSide;
   const variant = (isWinningSide && 'winner') || set?.winningSide ? 'loser' : undefined;
   const gameScore = sideNumber === 2 ? set.side2Score : set.side1Score;
-  const hasTiebreakScore = set.side2TiebreakScore || set.side1TiebreakScore;
+  const hasTiebreakScore = set.side2TiebreakScore !== undefined || set.side1TiebreakScore !== undefined;
   const tieBreakScore = sideNumber === 2 ? set.side2TiebreakScore : set.side1TiebreakScore;
-  const tieBreakSet = gameScore === undefined && tieBreakScore;
-  const scoreDisplay = tieBreakSet || gameScore;
+  // A "tiebreak set" is either a tiebreak-only set (no game score) or a final-set match
+  // tiebreak normalised by the engine to side{1,2}Score 1/0 with `tiebreakSet: true` and
+  // the actual points carried on side{1,2}TiebreakScore. In both cases the displayed value
+  // should be the tiebreak points, not the collapsed 1-0 game count.
+  const tieBreakSet = (gameScore === undefined || set.tiebreakSet === true) && tieBreakScore !== undefined;
+  const scoreDisplay = tieBreakSet ? tieBreakScore : gameScore;
   const stripedScore = scoreStripes && set.setNumber % 2 ? 'var(--chc-bg-secondary)' : 'transparent';
 
   const editing = set.editing;
@@ -163,7 +167,26 @@ export function renderSideScore({
 
   const inlineScoringConfig = composition?.configuration?.inlineScoring;
 
-  for (const set of sets || []) {
+  // Defensive enrichment: the factory persists tiebreakSet final sets with side1Score/side2Score
+  // collapsed to 1/0 and the actual tiebreak points only in `scoreStringSide{1,2}` (e.g. "[10-7]"),
+  // not on the set object. Without this fallback the per-set renderer has no TB points to display
+  // and shows the collapsed 1/0 instead.
+  const tokens1 = matchUp?.score?.scoreStringSide1?.split(/\s+/);
+  const tokens2 = matchUp?.score?.scoreStringSide2?.split(/\s+/);
+  const enrichTiebreakSet = (set: SetScore, index: number): SetScore => {
+    if (!set.tiebreakSet || set.side1TiebreakScore !== undefined || set.side2TiebreakScore !== undefined) return set;
+    const match1 = tokens1?.[index]?.match(/^\[(\d+)-(\d+)\]$/);
+    const match2 = tokens2?.[index]?.match(/^\[(\d+)-(\d+)\]$/);
+    if (!match1 && !match2) return set;
+    return {
+      ...set,
+      side1TiebreakScore: match1 ? Number(match1[1]) : match2 ? Number(match2[2]) : undefined,
+      side2TiebreakScore: match2 ? Number(match2[1]) : match1 ? Number(match1[2]) : undefined
+    };
+  };
+
+  for (const [index, rawSet] of (sets || []).entries()) {
+    const set = enrichTiebreakSet(rawSet, index);
     const setScoreDisplay = setScore({
       gameScoreOnly,
       scoreStripes,

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,7 @@ export interface SetScore {
   side2TiebreakScore?: number;
   side1PointScore?: number | string;
   side2PointScore?: number | string;
+  tiebreakSet?: boolean;
   winningSide?: number;
 }
 


### PR DESCRIPTION
## Summary

Before:
<img width="333" height="108" alt="Screenshot_2026-05-13_16-20-56" src="https://github.com/user-attachments/assets/741fa938-6752-4122-8457-cd04d606fbb3" />
After:
<img width="330" height="106" alt="Screenshot_2026-05-13_16-31-03" src="https://github.com/user-attachments/assets/b005dfc5-0a85-4ef1-8630-79705c5ca8c0" />


Final-set match tiebreaks (e.g. `SET3-S:6/TB7-F:TB10`) rendered as the collapsed `1`/`0` game count instead of the tiebreak points (`10`/`7`). The renderer ignored the `tiebreakSet` flag on the set object, and the persisted data shape made the fix more involved than a single guard.

Reproducing data for the affected match:
- Format: `SET3-S:6/TB7-F:TB10`
- Sets played: `7-5`, `6-7(4)`, championship tiebreak `10-7`
- `score.scoreStringSide1`: `"7-5 6-7(4) [10-7]"`
- Persisted set 3: `{ side1Score: 1, side2Score: 0, tiebreakSet: true, winningSide: 1 }` — note no `side1TiebreakScore`/`side2TiebreakScore`

## Root cause (two layers)

1. **Renderer ignored the flag.** `setScore` only treated a set as "tiebreak set" when `gameScore === undefined`. The engine normalises a final-set match tiebreak to `side1Score`/`side2Score` 1/0 with `tiebreakSet: true`, so the inference fails and the renderer shows the collapsed game count.
2. **Data shape lacks the points.** Honouring `set.tiebreakSet === true` and reading `side*TiebreakScore` on its own doesn't help here: `tods-competition-factory` persists tiebreakSet final sets without populating `side*TiebreakScore`. The actual points only live inside `score.scoreStringSide{1,2}` as a `[X-Y]` token.

## Fix

- `setScore`: honour `set.tiebreakSet === true` as a render-time trigger to display `side*TiebreakScore` instead of the collapsed game count. Adds the field to `SetScore`.
- `renderSideScore`: defensive fallback for the factory's incomplete data shape. If a `tiebreakSet: true` set lacks `side*TiebreakScore`, parse the bracketed token from `scoreStringSide1`/`scoreStringSide2` by set index and enrich the set before passing to `setScore`.

## Tests

Two unit tests added in `renderSideScore.test.ts`:
1. `setScore` displays the TB points when the set carries the normalised `tiebreakSet: true` + populated `side*TiebreakScore`.
2. `renderSideScore` recovers TB points from the `[X-Y]` token in `scoreStringSide{1,2}` when `side*TiebreakScore` is missing.

All 25 tests in the file pass. Other unrelated suites in this repo currently fail to load without a `tods-competition-factory` at the workspace path — not touched by this change.

## Upstream / factory note

This PR addresses the renderer side. The underlying data inconsistency is a `tods-competition-factory` issue — final-set match tiebreaks should carry `side1TiebreakScore`/`side2TiebreakScore` like every other tiebreak does, so the renderer (and any other consumer of the set object) gets consistent data. The two changes are independent: the renderer fix here is correct on its own, and the fallback handles already-stored matches without needing a backfill.

## Test plan

- [x] Unit tests added and passing locally
- [x] Lint clean on changed files
- [x] Manual: verified on a deployed instance against a real `SET3-S:6/TB7-F:TB10` match — draw cell now renders the championship tiebreak points instead of `1`/`0`.
