### PR TITLE
feat(burstChart): color segments by matchUp competitiveness

### DIFF
--- a/src/components/burstChart/__tests__/competitiveness.test.ts
+++ b/src/components/burstChart/__tests__/competitiveness.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  competitivenessColor,
+  competitivenessForMatchUp,
+  getCompetitivenessBand,
+  COMPETITIVENESS_COLORS,
+  NEUTRAL_SEGMENT_COLOR,
+  getCompetitivenessFromScoreString
+} from '../competitiveness';
+
+const set = (a: number, b: number, t1?: number, t2?: number) => ({
+  side1Score: a,
+  side2Score: b,
+  side1TiebreakScore: t1,
+  side2TiebreakScore: t2
+});
+
+describe('getCompetitivenessBand', () => {
+  it('classifies a lopsided score as DECISIVE', () => {
+    // 12 games to 1 -> spread 8% -> DECISIVE (<=20)
+    expect(getCompetitivenessBand([set(6, 0), set(6, 1)])).toBe('DECISIVE');
+  });
+
+  it('classifies a moderate score as ROUTINE', () => {
+    // 12 games to 5 -> spread 42% -> ROUTINE (<=50)
+    expect(getCompetitivenessBand([set(6, 2), set(6, 3)])).toBe('ROUTINE');
+  });
+
+  it('classifies a tight score as COMPETITIVE', () => {
+    // 12 games to 8 -> spread 67% -> COMPETITIVE (>50)
+    expect(getCompetitivenessBand([set(6, 4), set(6, 4)])).toBe('COMPETITIVE');
+  });
+
+  it('counts a match tiebreak as an extra game for its winner', () => {
+    // 1-1 in sets, third "set" is a match tiebreak won by side 1
+    const band = getCompetitivenessBand([set(6, 3), set(3, 6), set(0, 0, 10, 7)]);
+    expect(band).toBeDefined();
+  });
+
+  it('returns undefined when there is nothing to measure', () => {
+    expect(getCompetitivenessBand([])).toBeUndefined();
+    expect(getCompetitivenessBand(undefined)).toBeUndefined();
+    expect(getCompetitivenessBand([set(0, 0)])).toBeUndefined();
+  });
+
+  it('honors custom band thresholds', () => {
+    // 12-8 -> 67%; with ROUTINE raised to 70 it becomes ROUTINE
+    expect(getCompetitivenessBand([set(6, 4), set(6, 4)], { DECISIVE: 20, ROUTINE: 70 })).toBe('ROUTINE');
+  });
+});
+
+describe('getCompetitivenessFromScoreString', () => {
+  it('parses and classifies a score string', () => {
+    expect(getCompetitivenessFromScoreString('6-0 6-1')).toBe('DECISIVE');
+    expect(getCompetitivenessFromScoreString('6-2 6-3')).toBe('ROUTINE');
+    expect(getCompetitivenessFromScoreString('7-6(2) 6-7(4) 7-6(5)')).toBe('COMPETITIVE');
+  });
+
+  it('returns undefined for an empty score string', () => {
+    expect(getCompetitivenessFromScoreString(undefined)).toBeUndefined();
+    expect(getCompetitivenessFromScoreString('')).toBeUndefined();
+  });
+});
+
+describe('competitivenessForMatchUp', () => {
+  it('buckets walkovers/defaults by status', () => {
+    expect(competitivenessForMatchUp({ matchUpStatus: 'WALKOVER', winningSide: 1 })).toBe('WALKOVER');
+    expect(competitivenessForMatchUp({ matchUpStatus: 'DOUBLE_DEFAULT' })).toBe('WALKOVER');
+  });
+
+  it('returns undefined for undecided matchUps', () => {
+    expect(competitivenessForMatchUp({ matchUpStatus: 'TO_BE_PLAYED' })).toBeUndefined();
+    expect(competitivenessForMatchUp({ winningSide: undefined, scoreString: '6-1 6-2' })).toBeUndefined();
+  });
+
+  it('prefers structured sets but falls back to the score string', () => {
+    expect(competitivenessForMatchUp({ winningSide: 1, sets: [set(6, 0), set(6, 0)] })).toBe('DECISIVE');
+    expect(competitivenessForMatchUp({ winningSide: 1, scoreString: '6-4 6-4' })).toBe('COMPETITIVE');
+  });
+});
+
+describe('competitivenessColor', () => {
+  it('maps each bucket to the default palette', () => {
+    expect(competitivenessColor('COMPETITIVE')).toBe(COMPETITIVENESS_COLORS.COMPETITIVE);
+    expect(competitivenessColor('DECISIVE')).toBe(COMPETITIVENESS_COLORS.DECISIVE);
+  });
+
+  it('falls back to the neutral color when no bucket is given', () => {
+    expect(competitivenessColor(undefined)).toBe(NEUTRAL_SEGMENT_COLOR);
+  });
+
+  it('applies per-chart overrides', () => {
+    expect(competitivenessColor('COMPETITIVE', { COMPETITIVE: '#000000' })).toBe('#000000');
+  });
+});

--- a/src/components/burstChart/burstChart.ts
+++ b/src/components/burstChart/burstChart.ts
@@ -19,6 +19,8 @@ import { fixtures, entryStatusConstants } from 'tods-competition-factory';
 
 const { WILDCARD, QUALIFIER, LUCKY_LOSER } = entryStatusConstants;
 import { wordwrap } from './textHelpers';
+import { competitivenessColor, NEUTRAL_SEGMENT_COLOR } from './competitiveness';
+import { CompetitivenessBucket } from '../competitivenessBar/types';
 
 // ============================================================================
 // Constants
@@ -52,6 +54,7 @@ export interface SunburstMatchUp {
   winningSide?: number; // 1 or 2
   drawPositions: number[]; // [1, 2]
   scoreString?: string; // "6-2 7-6(2)"
+  competitiveness?: CompetitivenessBucket; // COMPETITIVE | ROUTINE | DECISIVE | WALKOVER (decided matchUps only)
   sides: SunburstSide[];
 }
 
@@ -78,10 +81,12 @@ export interface HierarchyNode {
   roundName?: string;
   scoreString?: string;
   matchUpStatus?: string;
+  competitiveness?: CompetitivenessBucket;
   matchUp?: SunburstMatchUp;
   depth: number;
   value?: number;
-  color?: string;
+  color?: string; // default (seed/entry) fill
+  competitivenessColor?: string; // fill used when colorMode === 'competitiveness'
   children?: HierarchyNode[];
   opponent?: HierarchyNode; // Set during hover to track opponent for flag display
 }
@@ -94,6 +99,7 @@ export interface SegmentData {
   nationalityCode?: string;
   scoreString?: string;
   matchUpStatus?: string;
+  competitiveness?: CompetitivenessBucket;
   roundName?: string;
   depth: number;
   matchUp?: SunburstMatchUp;
@@ -104,11 +110,25 @@ export interface BurstChartEventHandlers {
   clickCenter?: () => void;
 }
 
+/**
+ * Determines how segments are filled.
+ * - 'default' — seed / entry-status / draw-position coloring (original behavior)
+ * - 'competitiveness' — winner-ring segments colored by the competitiveness
+ *   bucket of the matchUp they represent; the outer entrant ring stays neutral.
+ *
+ * Modeled as an open string union so further modes can be added later.
+ */
+export type BurstColorMode = 'default' | 'competitiveness';
+
 export interface BurstChartOptions {
   width?: number;
   height?: number;
   title?: string;
   colorBySeeds?: boolean;
+  /** Initial color mode (default 'default'). Toggle at runtime via instance.setColorMode(). */
+  colorMode?: BurstColorMode;
+  /** Override the default competitiveness bucket palette. */
+  competitivenessColors?: Partial<Record<CompetitivenessBucket, string>>;
   countryCodes?: Record<string, string>;
   eventHandlers?: BurstChartEventHandlers;
   textScaleFactor?: number;
@@ -120,6 +140,8 @@ export interface BurstChartInstance {
   highlightPlayer: (playerName?: string) => number;
   /** Show or hide the entire chart SVG */
   hide: (hidden: boolean) => void;
+  /** Switch the segment coloring mode in place (no re-render). */
+  setColorMode: (mode: BurstColorMode) => void;
 }
 
 type GSelection = Selection<SVGGElement, unknown, null, undefined>;
@@ -220,6 +242,7 @@ function buildRoundParents(
       nationalityCode: winnerSide?.nationalityCode ?? winnerLookup?.nationalityCode,
       scoreString: mu.scoreString,
       matchUpStatus: mu.matchUpStatus,
+      competitiveness: mu.competitiveness,
       matchUp: mu,
       depth,
       children: children.length > 0 ? children : undefined
@@ -359,6 +382,24 @@ function applyColors(node: HierarchyNode, colorScale: ScaleLinear<number, number
       applyColors(child, colorScale);
     });
   }
+}
+
+/**
+ * Assign each node a `competitivenessColor` (used when colorMode is
+ * 'competitiveness'). Only winner-ring segments — nodes that have children and
+ * therefore represent the winner of a decided matchUp — are bucket-colored; the
+ * outer entrant ring (leaves) and undecided/BYE matches stay neutral, giving one
+ * competitiveness ring per round from R1 (outer) to the final (center).
+ */
+function applyCompetitivenessColors(
+  node: HierarchyNode,
+  overrides?: Partial<Record<CompetitivenessBucket, string>>
+): void {
+  if (!node) return;
+  const isWinnerRing = !!node.children?.length;
+  node.competitivenessColor =
+    isWinnerRing && node.competitiveness ? competitivenessColor(node.competitiveness, overrides) : NEUTRAL_SEGMENT_COLOR;
+  node.children?.forEach((child) => applyCompetitivenessColors(child, overrides));
 }
 
 // ============================================================================
@@ -577,6 +618,12 @@ export function renderburstChart(
     .range([0, 1]);
 
   applyColors(tournamentHierarchy, colorScale);
+  applyCompetitivenessColors(tournamentHierarchy, options.competitivenessColors);
+
+  // Active segment-coloring mode (toggled at runtime via setColorMode)
+  let colorMode: BurstColorMode = options.colorMode ?? 'default';
+  const fillForNode = (data: HierarchyNode): string =>
+    colorMode === 'competitiveness' ? data.competitivenessColor || NEUTRAL_SEGMENT_COLOR : data.color || '#ccc';
 
   // After partition(), nodes have x0/y0/x1/y1 properties
   const descendants = rootHierarchy.descendants() as HierarchyRectangularNode<HierarchyNode>[];
@@ -796,6 +843,7 @@ export function renderburstChart(
       nationalityCode: nodeData.nationalityCode,
       scoreString: nodeData.scoreString,
       matchUpStatus: nodeData.matchUpStatus,
+      competitiveness: nodeData.competitiveness,
       roundName: nodeData.roundName,
       depth: nodeData.depth,
       matchUp: nodeData.matchUp
@@ -808,7 +856,7 @@ export function renderburstChart(
     .data(descendants)
     .join('path')
     .attr('d', (d) => arc(d))
-    .attr('fill', (d) => d.data.color || '#ccc')
+    .attr('fill', (d) => fillForNode(d.data))
     .attr(ATTR_FILL_OPACITY, 0.8)
     .attr('stroke', '#fff')
     .attr('stroke-width', 1)
@@ -820,9 +868,11 @@ export function renderburstChart(
   }
 
   paths.append('title').text((node: any) => {
-    const nodeData = node.data;
+    const nodeData = node.data as HierarchyNode;
     if (nodeData.participantName) {
-      return `${nodeData.participantName}\nDraw: ${nodeData.drawPosition || 'N/A'}`;
+      const lines = [nodeData.participantName, `Draw: ${nodeData.drawPosition || 'N/A'}`];
+      if (nodeData.competitiveness) lines.push(`Competitiveness: ${nodeData.competitiveness}`);
+      return lines.join('\n');
     }
     return `${nodeData.name}\nDepth: ${node.depth}`;
   });
@@ -853,7 +903,14 @@ export function renderburstChart(
     svg.style('display', hidden ? 'none' : 'block');
   }
 
-  return { highlightPlayer, hide };
+  function setColorMode(mode: BurstColorMode): void {
+    colorMode = mode;
+    g.selectAll<SVGPathElement, HierarchyRectangularNode<HierarchyNode>>('path').attr('fill', (d) =>
+      fillForNode(d.data)
+    );
+  }
+
+  return { highlightPlayer, hide, setColorMode };
 }
 
 /**

--- a/src/components/burstChart/competitiveness.ts
+++ b/src/components/burstChart/competitiveness.ts
@@ -1,0 +1,124 @@
+/**
+ * Competitiveness classification + palette for burst-chart segments.
+ *
+ * Mirrors tods-competition-factory's default competitive-band logic
+ * (getScoreComponents + getBand) so the sunburst can classify a matchUp without
+ * depending on a factory export that may not be present in every consumer's
+ * installed/published build. Thresholds match POLICY_COMPETITIVE_BANDS_DEFAULT
+ * (DECISIVE <= 20, ROUTINE <= 50; otherwise COMPETITIVE).
+ *
+ * Buckets and the default palette are kept in sync with the sibling
+ * `competitivenessBar` component so competitiveness reads the same everywhere.
+ */
+
+import { scoreGovernor } from 'tods-competition-factory';
+
+import { CompetitivenessBucket } from '../competitivenessBar/types';
+
+// constants and types
+export type CompetitiveBands = { DECISIVE: number; ROUTINE: number };
+
+export const DEFAULT_COMPETITIVE_BANDS: CompetitiveBands = { DECISIVE: 20, ROUTINE: 50 };
+
+/** matchUpStatus values that represent a result with no games to measure. */
+export const WALKOVER_STATUSES = new Set(['WALKOVER', 'DOUBLE_WALKOVER', 'DEFAULTED', 'DOUBLE_DEFAULT']);
+
+/** Default segment fill per bucket — matches the competitivenessBar/donut palette. */
+export const COMPETITIVENESS_COLORS: Record<CompetitivenessBucket, string> = {
+  COMPETITIVE: '#16a34a', // --chc-status-success
+  ROUTINE: '#3b82f6', // --chc-status-info
+  DECISIVE: '#8e44ad',
+  WALKOVER: '#6b7280' // --chc-text-muted
+};
+
+/** Fill for segments with no measurable result (entrant ring, BYEs, undecided). */
+export const NEUTRAL_SEGMENT_COLOR = '#cfd8dc';
+
+const COMPETITIVE: CompetitivenessBucket = 'COMPETITIVE';
+const ROUTINE: CompetitivenessBucket = 'ROUTINE';
+const DECISIVE: CompetitivenessBucket = 'DECISIVE';
+const WALKOVER: CompetitivenessBucket = 'WALKOVER';
+
+interface ScoreSet {
+  side1Score?: number;
+  side2Score?: number;
+  side1TiebreakScore?: number;
+  side2TiebreakScore?: number;
+}
+
+/**
+ * Classify a structured score (array of sets) into a competitiveness bucket.
+ * Returns undefined when there is nothing to measure (no sets / no games).
+ */
+export function getCompetitivenessBand(
+  sets: ScoreSet[] | undefined,
+  bands: CompetitiveBands = DEFAULT_COMPETITIVE_BANDS
+): CompetitivenessBucket | undefined {
+  if (!sets?.length) return undefined;
+
+  const games = [0, 0];
+  const tiebreaks = [0, 0];
+  for (const set of sets) {
+    games[0] += set.side1Score || 0;
+    games[1] += set.side2Score || 0;
+    tiebreaks[0] += set.side1TiebreakScore || 0;
+    tiebreaks[1] += set.side2TiebreakScore || 0;
+  }
+  // a match (super-)tiebreak counts as one extra game for its winner
+  if (tiebreaks[0] + tiebreaks[1]) games[tiebreaks[0] > tiebreaks[1] ? 0 : 1] += 1;
+
+  const maxGames = Math.max(games[0], games[1]);
+  if (maxGames === 0) return undefined;
+
+  const spread = Math.round((Math.min(games[0], games[1]) / maxGames) * 100);
+  if (Number.isNaN(spread)) return WALKOVER;
+  if (spread <= bands.DECISIVE) return DECISIVE;
+  if (spread <= bands.ROUTINE) return ROUTINE;
+  return COMPETITIVE;
+}
+
+/**
+ * Classify a score string (e.g. "6-2 7-6(2)") into a competitiveness bucket.
+ * Used by the legacy-draw adapter where only score strings are available.
+ */
+export function getCompetitivenessFromScoreString(
+  scoreString: string | undefined,
+  bands: CompetitiveBands = DEFAULT_COMPETITIVE_BANDS
+): CompetitivenessBucket | undefined {
+  if (!scoreString) return undefined;
+  const sets = scoreGovernor.parseScoreString({ scoreString });
+  return getCompetitivenessBand(sets, bands);
+}
+
+/**
+ * Single classification entry point used by both draw adapters. Prefers the
+ * structured score (`sets`); falls back to parsing a `scoreString`. Walkovers /
+ * defaults are bucketed by status since they carry no games.
+ */
+export function competitivenessForMatchUp({
+  winningSide,
+  matchUpStatus,
+  sets,
+  scoreString,
+  bands
+}: {
+  winningSide?: number;
+  matchUpStatus?: string;
+  sets?: ScoreSet[];
+  scoreString?: string;
+  bands?: CompetitiveBands;
+}): CompetitivenessBucket | undefined {
+  if (matchUpStatus && WALKOVER_STATUSES.has(matchUpStatus)) return WALKOVER;
+  if (!winningSide) return undefined;
+  if (sets?.length) return getCompetitivenessBand(sets, bands);
+  return getCompetitivenessFromScoreString(scoreString, bands);
+}
+
+/** Resolve the fill color for a bucket, honoring per-chart overrides. */
+export function competitivenessColor(
+  bucket: CompetitivenessBucket | undefined,
+  overrides?: Partial<Record<CompetitivenessBucket, string>>
+): string {
+  if (!bucket) return NEUTRAL_SEGMENT_COLOR;
+  return overrides?.[bucket] ?? COMPETITIVENESS_COLORS[bucket];
+}

--- a/src/components/burstChart/matchUpTransform.ts
+++ b/src/components/burstChart/matchUpTransform.ts
@@ -8,6 +8,7 @@
  */
 
 import { entryStatusConstants } from 'tods-competition-factory';
+import { competitivenessForMatchUp } from './competitiveness';
 import type { SunburstDrawData, SunburstMatchUp, SunburstSide } from './burstChart';
 
 const { LUCKY_LOSER, WILDCARD, QUALIFIER } = entryStatusConstants;
@@ -28,6 +29,11 @@ export function fromFactoryDrawData(structure: any): SunburstDrawData {
       ...mu,
       winningSide: mu.winningSide,
       drawPositions: mu.drawPositions || [],
+      competitiveness: competitivenessForMatchUp({
+        winningSide: mu.winningSide,
+        matchUpStatus: mu.matchUpStatus,
+        sets: mu.score?.sets
+      }),
       scoreString:
         mu.winningSide === 1
           ? mu.score?.scoreStringSide1
@@ -191,6 +197,7 @@ function buildRound1MatchUps(
       matchUpStatus,
       winningSide,
       drawPositions: [p1?.Draw ?? i + 1, p2?.Draw ?? i + 2],
+      competitiveness: competitivenessForMatchUp({ winningSide, matchUpStatus, scoreString }),
       scoreString,
       sides: [makeSide(1, p1, i + 1), makeSide(2, p2, i + 2)]
     });
@@ -225,6 +232,7 @@ function buildSubsequentRoundMatchUps(
       matchUpStatus,
       winningSide,
       drawPositions: [playerInfoMap.get(name1)?.drawPosition ?? 0, playerInfoMap.get(name2)?.drawPosition ?? 0],
+      competitiveness: competitivenessForMatchUp({ winningSide, matchUpStatus, scoreString }),
       scoreString,
       sides: [makeSideFromLookup(1, p1, playerInfoMap), makeSideFromLookup(2, p2, playerInfoMap)]
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,11 +287,21 @@ export type {
   SunburstMatchUp,
   SunburstSide,
   SegmentData,
+  BurstColorMode,
   BurstChartEventHandlers,
   BurstChartOptions,
   BurstChartInstance
 } from './components/burstChart/burstChart';
 export { fromFactoryDrawData, fromLegacyDraw } from './components/burstChart/matchUpTransform';
+export {
+  competitivenessColor,
+  getCompetitivenessBand,
+  COMPETITIVENESS_COLORS,
+  NEUTRAL_SEGMENT_COLOR,
+  DEFAULT_COMPETITIVE_BANDS,
+  getCompetitivenessFromScoreString
+} from './components/burstChart/competitiveness';
+export type { CompetitiveBands } from './components/burstChart/competitiveness';
 
 // Rating Distribution Chart — histogram + donut visualization for the format wizard
 // (data shape comes from tods-competition-factory: RatingDistributionStats / DistributionBin)

--- a/src/stories/burstChart.stories.ts
+++ b/src/stories/burstChart.stories.ts
@@ -18,8 +18,9 @@ import {
   matchUpStatusConstants
 } from 'tods-competition-factory';
 import { fromLegacyDraw, fromFactoryDrawData } from '../components/burstChart/matchUpTransform';
-import type { BurstChartInstance } from '../components/burstChart/burstChart';
+import type { BurstChartInstance, BurstColorMode } from '../components/burstChart/burstChart';
 import { burstChart } from '../components/burstChart/burstChart';
+import { COMPETITIVENESS_COLORS, NEUTRAL_SEGMENT_COLOR } from '../components/burstChart/competitiveness';
 
 // data imports
 import australianOpenData from '../data/burstChart/australian_open.json';
@@ -40,6 +41,90 @@ const BORDER_STYLE_1 = '1px solid var(--chc-border-secondary)';
 const BORDER_STYLE_2 = '1px solid var(--chc-border-primary)';
 const CLICKED_SEGMENT = 'Clicked segment:';
 const CLICKED_CENTER = 'Clicked center!';
+
+const COMPETITIVENESS_LEGEND: { bucket: string; label: string; color: string }[] = [
+  { bucket: 'COMPETITIVE', label: 'Competitive', color: COMPETITIVENESS_COLORS.COMPETITIVE },
+  { bucket: 'ROUTINE', label: 'Routine', color: COMPETITIVENESS_COLORS.ROUTINE },
+  { bucket: 'DECISIVE', label: 'Decisive', color: COMPETITIVENESS_COLORS.DECISIVE },
+  { bucket: 'WALKOVER', label: 'Walkover', color: COMPETITIVENESS_COLORS.WALKOVER },
+  { bucket: 'NEUTRAL', label: 'Entrant / not played', color: NEUTRAL_SEGMENT_COLOR }
+];
+
+/** Build a small swatch legend describing the competitiveness palette. */
+function buildCompetitivenessLegend(): HTMLElement {
+  const legend = document.createElement('div');
+  legend.style.display = 'flex';
+  legend.style.flexWrap = 'wrap';
+  legend.style.gap = '14px';
+  legend.style.alignItems = 'center';
+  legend.style.fontSize = '13px';
+  legend.style.color = CHC_TEXT_SECONDARY;
+
+  for (const { label, color } of COMPETITIVENESS_LEGEND) {
+    const item = document.createElement('span');
+    item.style.display = 'inline-flex';
+    item.style.alignItems = 'center';
+    item.style.gap = '6px';
+
+    const swatch = document.createElement('span');
+    swatch.style.width = '14px';
+    swatch.style.height = '14px';
+    swatch.style.borderRadius = '3px';
+    swatch.style.background = color;
+    swatch.style.display = 'inline-block';
+
+    const text = document.createElement('span');
+    text.textContent = label;
+
+    item.appendChild(swatch);
+    item.appendChild(text);
+    legend.appendChild(item);
+  }
+
+  return legend;
+}
+
+/** Build a Default / Competitiveness mode toggle wired to the supplied callback. */
+function buildModeToggle(onChange: (mode: BurstColorMode) => void): HTMLElement {
+  const group = document.createElement('div');
+  group.style.display = 'inline-flex';
+  group.style.gap = '8px';
+  group.style.alignItems = 'center';
+
+  const modes: { mode: BurstColorMode; label: string }[] = [
+    { mode: 'default', label: 'Default (seeds)' },
+    { mode: 'competitiveness', label: 'Competitiveness' }
+  ];
+
+  const buttons: HTMLButtonElement[] = [];
+  const paint = (active: BurstColorMode) => {
+    for (const btn of buttons) {
+      const isActive = btn.dataset.mode === active;
+      btn.style.background = isActive ? '#1565C0' : CHC_BG_PRIMARY;
+      btn.style.color = isActive ? '#fff' : CHC_TEXT_PRIMARY;
+    }
+  };
+
+  for (const { mode, label } of modes) {
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    btn.dataset.mode = mode;
+    btn.style.padding = '6px 12px';
+    btn.style.fontSize = '14px';
+    btn.style.borderRadius = '4px';
+    btn.style.border = BORDER_STYLE_2;
+    btn.style.cursor = 'pointer';
+    btn.addEventListener('click', () => {
+      onChange(mode);
+      paint(mode);
+    });
+    buttons.push(btn);
+    group.appendChild(btn);
+  }
+
+  paint('competitiveness');
+  return group;
+}
 
 interface BurstChartArgs {
   width: number;
@@ -905,6 +990,140 @@ export const AustralianOpenPlayerSearch: Story = {
     searchInput.addEventListener('blur', () => {
       searchInput.style.borderColor = 'var(--chc-border-secondary)';
     });
+
+    return wrapper;
+  }
+};
+
+/**
+ * Competitiveness Coloring - color each winner-ring segment by the competitiveness
+ * bucket of the matchUp it represents.
+ *
+ * With colorMode 'competitiveness', every segment that represents a decided match
+ * (the winner rings, from round 1 on the outside to the final at the center) is
+ * filled by how close that match was: Competitive / Routine / Decisive / Walkover.
+ * The outer entrant ring stays neutral. This makes two things visible at a glance:
+ * - whether matches get more competitive toward the final (read radially, inward)
+ * - whether a given player kept having close matches or routine wins (follow their wedge)
+ *
+ * Toggle between Default (seed/entry coloring) and Competitiveness without re-rendering.
+ */
+export const CompetitivenessColoring: Story = {
+  args: {
+    width: 800,
+    height: 800,
+    title: 'Competitiveness'
+  },
+  render: (args: any) => {
+    const wrapper = document.createElement('div');
+    wrapper.style.padding = '20px';
+    wrapper.style.backgroundColor = CHC_BG_SECONDARY;
+    wrapper.style.color = CHC_TEXT_PRIMARY;
+
+    // Controls row: color-mode toggle + draw size + regenerate
+    const controls = document.createElement('div');
+    controls.style.display = 'flex';
+    controls.style.flexWrap = 'wrap';
+    controls.style.gap = '16px';
+    controls.style.alignItems = 'center';
+    controls.style.marginBottom = '16px';
+    controls.style.padding = '15px';
+    controls.style.backgroundColor = CHC_BG_ELEVATED;
+    controls.style.borderRadius = '8px';
+    controls.style.border = BORDER_STYLE_1;
+
+    const sizeLabel = document.createElement('span');
+    sizeLabel.textContent = 'Draw Size: ';
+    sizeLabel.style.fontWeight = 'bold';
+    const sizeSelect = document.createElement('select');
+    sizeSelect.style.padding = '6px 10px';
+    sizeSelect.style.fontSize = '14px';
+    sizeSelect.style.borderRadius = '4px';
+    sizeSelect.style.border = BORDER_STYLE_2;
+    sizeSelect.style.backgroundColor = CHC_BG_PRIMARY;
+    sizeSelect.style.color = CHC_TEXT_PRIMARY;
+    for (const size of [16, 32, 64, 128]) {
+      const opt = document.createElement('option');
+      opt.value = String(size);
+      opt.textContent = String(size);
+      if (size === 32) opt.selected = true;
+      sizeSelect.appendChild(opt);
+    }
+
+    const regenButton = document.createElement('button');
+    regenButton.textContent = 'Regenerate';
+    regenButton.style.padding = '8px 16px';
+    regenButton.style.fontSize = '14px';
+    regenButton.style.borderRadius = '4px';
+    regenButton.style.border = '1px solid #1565C0';
+    regenButton.style.backgroundColor = '#1565C0';
+    regenButton.style.color = '#fff';
+    regenButton.style.cursor = 'pointer';
+
+    // Chart + legend
+    const chartContainer = document.createElement('div');
+    chartContainer.style.backgroundColor = CHC_BG_ELEVATED;
+    chartContainer.style.border = BORDER_STYLE_1;
+    chartContainer.style.borderRadius = '8px';
+    chartContainer.style.display = 'flex';
+    chartContainer.style.alignItems = 'center';
+    chartContainer.style.justifyContent = 'center';
+
+    const legend = buildCompetitivenessLegend();
+    legend.style.margin = '16px 0';
+
+    let instance: BurstChartInstance | undefined;
+    let mode: BurstColorMode = 'competitiveness';
+
+    function generate() {
+      const drawSize = Number.parseInt(sizeSelect.value, 10);
+      const seedsCount = Math.min(8, drawSize / 2);
+
+      const { tournamentRecord, drawIds } = mocksEngine.generateTournamentRecord({
+        drawProfiles: [{ drawSize, drawType: SINGLE_ELIMINATION, seedsCount }],
+        completeAllMatchUps: true,
+        randomWinningSide: true
+      });
+      tournamentEngine.setState(tournamentRecord);
+
+      const drawId = drawIds[0];
+      const { eventData } = tournamentEngine.getEventData({ drawId });
+      const structure = eventData.drawsData.find((d: any) => d.drawId === drawId).structures[0];
+      const drawData = fromFactoryDrawData(structure);
+
+      chartContainer.innerHTML = '';
+      const chart = burstChart({
+        width: args.width,
+        height: args.height,
+        colorMode: mode,
+        eventHandlers: {
+          clickSegment: (data) => {
+            console.log(CLICKED_SEGMENT, data.participantName, '|', data.competitiveness, '|', data.scoreString);
+          }
+        }
+      });
+
+      instance = chart.render(chartContainer, drawData, `${args.title} (${drawSize}-draw)`);
+    }
+
+    const toggle = buildModeToggle((m) => {
+      mode = m;
+      instance?.setColorMode(m);
+    });
+
+    controls.appendChild(toggle);
+    controls.appendChild(sizeLabel);
+    controls.appendChild(sizeSelect);
+    controls.appendChild(regenButton);
+
+    regenButton.addEventListener('click', generate);
+    sizeSelect.addEventListener('change', generate);
+
+    generate();
+
+    wrapper.appendChild(controls);
+    wrapper.appendChild(legend);
+    wrapper.appendChild(chartContainer);
 
     return wrapper;
   }

--- a/src/stories/burstChart.stories.ts
+++ b/src/stories/burstChart.stories.ts
@@ -84,6 +84,68 @@ function buildCompetitivenessLegend(): HTMLElement {
   return legend;
 }
 
+const COMPETITIVENESS_USAGE_SNIPPET = `import { burstChart, fromFactoryDrawData } from 'courthive-components';
+
+// Enabling competitiveness coloring is a single option — that's all it takes:
+const chart = burstChart({ colorMode: 'competitiveness' });
+chart.render(container, fromFactoryDrawData(structure), title);
+
+// Optional:
+// - toggle at runtime without re-rendering
+const instance = chart.render(container, drawData, title);
+instance.setColorMode('default');          // back to seed/entry coloring
+instance.setColorMode('competitiveness');  // ...and back again
+
+// - override the bucket palette
+burstChart({
+  colorMode: 'competitiveness',
+  competitivenessColors: { COMPETITIVE: '#16a34a', DECISIVE: '#b91c1c' },
+});`;
+
+/** Build a panel that documents the minimal usage for competitiveness coloring. */
+function buildUsagePanel(): HTMLElement {
+  const panel = document.createElement('div');
+  panel.style.margin = '16px 0';
+  panel.style.padding = '16px';
+  panel.style.backgroundColor = CHC_BG_ELEVATED;
+  panel.style.border = BORDER_STYLE_1;
+  panel.style.borderRadius = '8px';
+
+  const heading = document.createElement('h3');
+  heading.textContent = 'Usage';
+  heading.style.margin = '0 0 8px 0';
+  heading.style.color = CHC_TEXT_PRIMARY;
+  panel.appendChild(heading);
+
+  const lead = document.createElement('p');
+  lead.style.margin = '0 0 12px 0';
+  lead.style.fontSize = '14px';
+  lead.style.color = CHC_TEXT_SECONDARY;
+  lead.innerHTML =
+    "Pass <code>colorMode: 'competitiveness'</code> when creating the chart — nothing else is required. " +
+    'The competitiveness of each decided matchUp is computed automatically inside the draw adapters ' +
+    '(<code>fromFactoryDrawData</code> / <code>fromLegacyDraw</code>), so the data you already pass to ' +
+    '<code>render()</code> is enough. Winner-ring segments are colored by bucket; the outer entrant ring stays neutral.';
+  panel.appendChild(lead);
+
+  const pre = document.createElement('pre');
+  pre.style.margin = '0';
+  pre.style.padding = '12px';
+  pre.style.backgroundColor = CHC_BG_SECONDARY;
+  pre.style.borderRadius = '4px';
+  pre.style.overflowX = 'auto';
+  pre.style.fontSize = '12.5px';
+  pre.style.lineHeight = '1.5';
+  pre.style.color = CHC_TEXT_PRIMARY;
+
+  const code = document.createElement('code');
+  code.textContent = COMPETITIVENESS_USAGE_SNIPPET;
+  pre.appendChild(code);
+  panel.appendChild(pre);
+
+  return panel;
+}
+
 /** Build a Default / Competitiveness mode toggle wired to the supplied callback. */
 function buildModeToggle(onChange: (mode: BurstColorMode) => void): HTMLElement {
   const group = document.createElement('div');
@@ -999,14 +1061,30 @@ export const AustralianOpenPlayerSearch: Story = {
  * Competitiveness Coloring - color each winner-ring segment by the competitiveness
  * bucket of the matchUp it represents.
  *
- * With colorMode 'competitiveness', every segment that represents a decided match
- * (the winner rings, from round 1 on the outside to the final at the center) is
- * filled by how close that match was: Competitive / Routine / Decisive / Walkover.
- * The outer entrant ring stays neutral. This makes two things visible at a glance:
+ * ## How to use it
+ *
+ * Enabling this is a single option — pass `colorMode: 'competitiveness'` when you
+ * create the chart and you're done:
+ *
+ * ```ts
+ * const chart = burstChart({ colorMode: 'competitiveness' });
+ * chart.render(container, fromFactoryDrawData(structure), title);
+ * ```
+ *
+ * No extra data is required: the competitiveness of each decided matchUp is computed
+ * automatically inside the draw adapters (`fromFactoryDrawData` / `fromLegacyDraw`),
+ * so whatever you already pass to `render()` is enough. You can flip modes at runtime
+ * without re-rendering via `instance.setColorMode('default' | 'competitiveness')`, and
+ * override the bucket palette with the `competitivenessColors` option.
+ *
+ * ## What it shows
+ *
+ * Every segment that represents a decided match (the winner rings, from round 1 on the
+ * outside to the final at the center) is filled by how close that match was:
+ * Competitive / Routine / Decisive / Walkover. The outer entrant ring stays neutral.
+ * This makes two things visible at a glance:
  * - whether matches get more competitive toward the final (read radially, inward)
  * - whether a given player kept having close matches or routine wins (follow their wedge)
- *
- * Toggle between Default (seed/entry coloring) and Competitiveness without re-rendering.
  */
 export const CompetitivenessColoring: Story = {
   args: {
@@ -1124,6 +1202,7 @@ export const CompetitivenessColoring: Story = {
     wrapper.appendChild(controls);
     wrapper.appendChild(legend);
     wrapper.appendChild(chartContainer);
+    wrapper.appendChild(buildUsagePanel());
 
     return wrapper;
   }


### PR DESCRIPTION
## What

Adds an opt-in `colorMode: 'competitiveness'` to the Sunburst (burstChart) so each winner-ring segment is filled by the competitiveness bucket of the matchUp it represents (COMPETITIVE / ROUTINE / DECISIVE / WALKOVER); the outer entrant ring stays neutral — one competitiveness ring per round from R1 (outer) to the final (center).

- self-contained classifier (`burstChart/competitiveness.ts`) mirroring the factory default bands (DECISIVE ≤ 20, ROUTINE ≤ 50); legacy score strings parsed via `scoreGovernor.parseScoreString`
- both draw adapters attach `competitiveness` per matchUp
- `colorMode` + `competitivenessColors` options and a `setColorMode()` instance method (toggle in place, no re-render); competitiveness surfaced in the hover title and clickSegment payload
- palette reused from the `competitivenessBar` component for consistency
- `CompetitivenessColoring` story (usage panel + legend), unit tests, index exports

Backward compatible — default mode is unchanged.

## Tests
ESLint clean; vitest 1359 passing (+14); build OK.