### PR TITLE
refactor: read draftState first-class with extension fallback (5.0.0 readiness)

### DIFF
--- a/src/components/event-card/mapEvent.ts
+++ b/src/components/event-card/mapEvent.ts
@@ -101,7 +101,11 @@ function walkMatchUps(drawDefinitions: any[]): EventMatchUpCounts {
 // Draft-state detection
 // ============================================================================
 
-function hasDraftStateExtension(draw: any): boolean {
+function hasDraftState(draw: any): boolean {
+  // CODES 5.0.0: draftState may be a first-class draw attribute (NATIVE mode)
+  // or a legacy extension (LEGACY mode). Check both — components is a pure
+  // UI library and does not call the factory engine.
+  if (draw?.draftState != null) return true;
   const extensions = draw?.extensions;
   if (!Array.isArray(extensions)) return false;
   return extensions.some((ext: any) => ext?.name === DRAFT_STATE_EXTENSION);
@@ -109,7 +113,7 @@ function hasDraftStateExtension(draw: any): boolean {
 
 function hasSeedsOnlyDraw(drawDefinitions: any[]): boolean {
   return drawDefinitions.some(
-    (d) => d?.automated?.seedsOnly === true || hasDraftStateExtension(d)
+    (d) => d?.automated?.seedsOnly === true || hasDraftState(d)
   );
 }
 
@@ -182,7 +186,7 @@ export function mapEventToCardData(event: any, options?: MapEventOptions): Event
             startDate: event?.startDate,
             endDate: event?.endDate,
             matchUpCounts,
-            hasDraftState: drawDefinitions.some(hasDraftStateExtension),
+            hasDraftState: drawDefinitions.some(hasDraftState),
             hasSeedsOnlyDraw: hasSeedsOnlyDraw(drawDefinitions)
           },
           options?.now


### PR DESCRIPTION
## Summary

Factory 5.0.0 promotes \`draftState\` to a first-class \`DrawDefinition\` attribute (CODES Phase 4). In NATIVE mode (the new 5.0.0 default) it is no longer written as a legacy extension, so \`extensions.some(ext.name === DRAFT_STATE)\` silently returns \`false\` for any draw written under the new mode — making affected event cards lose their "draft in progress" visual cue.

This PR updates \`mapEvent.ts\` to check \`draw.draftState\` first (covering NATIVE-written records), then fall back to the extension lookup (covering LEGACY/DUAL-written and pre-5.0.0 records). Function renamed from \`hasDraftStateExtension\` to \`hasDraftState\` to reflect the mode-agnostic behavior.

Since \`courthive-components\` is a pure UI library and does not call the factory engine, the fallback is inlined rather than routed through a factory query method.

## What changes

- \`src/components/event-card/mapEvent.ts\` — 1 function renamed + 4 lines of mode-agnostic logic

## Verification

- \`pnpm lint\` — green
- \`pnpm test\` — 66 files / 1359 pass / 0 fail
- \`pnpm build\` — green

## Test plan

- [ ] CI green
- [ ] Once factory 5.0.0 is published and TMX picks it up, confirm event cards still surface the "draft in progress" indicator for drafts written under both LEGACY and NATIVE modes