### PR TITLE
chore(deps): bump tods-competition-factory to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "focus-trap": "^8.0.0",
     "timepicker-ui": "^4.1.2",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "4.2.0",
+    "tods-competition-factory": "5.0.0",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps `tods-competition-factory` from `4.2.0` to `5.0.0` (published 2026-05-31)
- Picks up the CODES Phase 0-7 schema migration (NATIVE write mode default), `TemporalEngine` → `AvailabilityEngine` rename, typed engines by default, and the JOY/forge feature set
- See factory's [4.x → 5.0.0 migration guide](https://github.com/CourtHive/competition-factory/blob/master/documentation/docs/migration/4.x-to-5.0.0.md) for the breaking surface

## Pre-flight scan

- Raw extension reads of promoted CODES names (`tally`, `subOrder`, `flightProfile`, `lineUps`, `SCHEDULING_PROFILE`, `SCHEDULE_LIMITS`, `SCHEDULE_TIMING`): **0 hits** in `src/`
- Raw `matchUp.timeItems` reads for promoted `SCHEDULED_*` / `ASSIGN_*`: **0 hits** in `src/`
- `TemporalEngine` references: **3 hits**, all in `dev/docs/temporalEngine/` (non-production vanilla prototype) — worth a follow-up cleanup but not a blocker

## Local verification (linked factory tree, already on 5.0.0)

- `pnpm lint` — clean
- `pnpm test` — 1390 tests pass across 67 files
- `pnpm build` — UMD + ES bundles + `.d.ts` declarations all produced

## Test plan

- [ ] CI strip-link path resolves `5.0.0` from npm and reruns lint/test/build
- [ ] Storybook still renders core stories