### PR TITLE
feat(availability-grid): onManageRegistrations callback on block popover

### DIFF
--- a/src/components/availability-grid/controller/availabilityGridControl.ts
+++ b/src/components/availability-grid/controller/availabilityGridControl.ts
@@ -87,6 +87,21 @@ export interface AvailabilityGridControlConfig {
    * native browser alert).
    */
   onConflict?: (conflicts: any[]) => void;
+
+  /**
+   * Optional callback rendered as a "Manage Registrations" menu item on
+   * the block popover for PRACTICE blocks. The argument carries the
+   * resolved block descriptor — consumers use it to open their practice-
+   * registration management surface (e.g. a cModal in TMX).
+   */
+  onManageRegistrations?: (args: {
+    blockId: string;
+    courtId: string;
+    venueId: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+  }) => void;
 }
 
 // ============================================================================
@@ -677,7 +692,8 @@ export class AvailabilityGridControl {
         blockId,
         engine: this.engine,
         day,
-        onBlockChanged: () => this.render()
+        onBlockChanged: () => this.render(),
+        onManageRegistrations: this.config.onManageRegistrations
       });
     }
 
@@ -725,7 +741,8 @@ export class AvailabilityGridControl {
             blockId: newBlockId,
             engine: this.engine,
             day,
-            onBlockChanged: () => this.render()
+            onBlockChanged: () => this.render(),
+            onManageRegistrations: this.config.onManageRegistrations
           });
         }
       }, 50);

--- a/src/components/availability-grid/ui/availabilityGrid.ts
+++ b/src/components/availability-grid/ui/availabilityGrid.ts
@@ -209,6 +209,7 @@ export class AvailabilityGrid {
         onBlockSelected: this.handleBlockSelected,
         onCourtSelected: this.handleCourtSelected,
         onTimeRangeSelected: this.handleTimeRangeSelected,
+        onManageRegistrations: this.config.onManageRegistrations,
         onBlocksChanged: () => {
           this.updateCapacityStats();
           this.updateStatsBar();

--- a/src/components/availability-grid/ui/blockPopover.ts
+++ b/src/components/availability-grid/ui/blockPopover.ts
@@ -39,6 +39,21 @@ export interface EngineBlockPopoverOptions {
   engine: AvailabilityEngine;
   day: string;
   onBlockChanged: () => void;
+  /**
+   * Optional callback rendered as a "Manage Registrations" menu item for
+   * PRACTICE blocks. Provides the resolved block descriptor (courtId, date,
+   * sub-window times) so the consumer can resolve to its bookingId without
+   * a round trip — the factory derives bookingId from `${courtId}-${date}-${startTime}`
+   * when the booking lacks an explicit one.
+   */
+  onManageRegistrations?: (args: {
+    blockId: string;
+    courtId: string;
+    venueId: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+  }) => void;
 }
 
 export interface BlockPopoverManager {
@@ -160,7 +175,7 @@ export function createBlockPopoverManager(): BlockPopoverManager {
   }
 
   function buildEngineContent(opts: EngineBlockPopoverOptions): HTMLElement {
-    const { blockId, engine, day, onBlockChanged } = opts;
+    const { blockId, engine, day, onBlockChanged, onManageRegistrations } = opts;
 
     const wrap = document.createElement('div');
     wrap.style.cssText = 'font-family:sans-serif; font-size:13px; min-width:150px;';
@@ -238,6 +253,37 @@ export function createBlockPopoverManager(): BlockPopoverManager {
     });
     wrap.appendChild(timeBtn);
 
+    // Manage Registrations (PRACTICE only — Manage practice court registrants
+    // for this booking's sub-windows. The consumer provides the modal.)
+    const currentBlock = engine.getDayBlocks(day).find((b) => b.id === blockId);
+    if (onManageRegistrations && currentBlock?.type === BLOCK_TYPES.PRACTICE) {
+      const manageBtn = document.createElement('div');
+      manageBtn.style.cssText = POPOVER_ITEM_STYLE;
+      manageBtn.innerHTML = `<span style="font-size:14px;">&#128101;</span> Manage Registrations`;
+      manageBtn.addEventListener('mouseenter', () => {
+        manageBtn.style.background = CHC_HOVER_BG;
+        manageBtn.style.color = CHC_TEXT_PRIMARY;
+      });
+      manageBtn.addEventListener('mouseleave', () => {
+        manageBtn.style.background = 'transparent';
+        manageBtn.style.color = '';
+      });
+      manageBtn.addEventListener('click', () => {
+        destroyActive();
+        const block = engine.getDayBlocks(day).find((b) => b.id === blockId);
+        if (!block) return;
+        onManageRegistrations({
+          blockId,
+          courtId: block.court.courtId,
+          venueId: block.court.venueId,
+          date: day,
+          startTime: extractHM(block.start),
+          endTime: extractHM(block.end),
+        });
+      });
+      wrap.appendChild(manageBtn);
+    }
+
     // Delete
     const delBtn = document.createElement('div');
     delBtn.style.cssText =
@@ -257,6 +303,16 @@ export function createBlockPopoverManager(): BlockPopoverManager {
     wrap.appendChild(delBtn);
 
     return wrap;
+  }
+
+  /**
+   * Extracts an `HH:MM` string from either an ISO datetime (`2026-06-15T14:00:00`)
+   * or a bare time (`14:00:00` / `14:00`). The engine produces ISO times; the
+   * factory's bookingId derivation uses bare HH:MM.
+   */
+  function extractHM(iso: string): string {
+    const timePart = iso.includes('T') ? iso.split('T')[1] : iso;
+    return timePart.slice(0, 5);
   }
 
   function showTip(target: HTMLElement, content: HTMLElement, itemId: string): void {


### PR DESCRIPTION
Adds a PRACTICE-only "Manage Registrations" menu item to the
AvailabilityGrid engine-block popover. When the consumer passes an
`onManageRegistrations` callback (new on `AvailabilityGridConfig` +
`AvailabilityGridControlConfig` + `EngineBlockPopoverOptions`), the
popover renders the menu item below Adjust Time / Delete and invokes
the callback with the resolved block descriptor —
`{ blockId, courtId, venueId, date, startTime, endTime }` — on click.

Designed to pair with TMX's `openManagePracticeRegistrationsModal`
(committed in TMX `354b8b54` on main). The descriptor's `startTime`
maps to the factory's bookingId-derivation shape
`\${courtId}-\${date}-\${startTime}`, so the consumer can resolve to a
specific PRACTICE booking without a round-trip.

Non-PRACTICE blocks and the no-callback case render unchanged.

CI matrix green: 1390 vitest tests + lint + build clean.