### PR TITLE
feat(schedule-page): render practice registrations on PRACTICE cells

### DIFF
--- a/src/components/schedule-page/types.ts
+++ b/src/components/schedule-page/types.ts
@@ -343,5 +343,13 @@ export interface ScheduleCellData {
     bookingType?: string;
     rowCount?: number;
     notes?: string;
+    /**
+     * Participant labels to render below the booking type. Pre-formatted
+     * by the consumer so the cell stays display-only — e.g.
+     * `["Smith / Jones (14:00–14:30)", "Ortiz (14:30–15:00)"]`. The
+     * Now/Live strip integration for PRACTICE bookings (practice court
+     * registration) is the first consumer.
+     */
+    registrations?: string[];
   };
 }

--- a/src/components/schedule-page/ui/schedule-grid-cell.css
+++ b/src/components/schedule-page/ui/schedule-grid-cell.css
@@ -383,6 +383,25 @@
   white-space: nowrap;
 }
 
+.spl-grid-cell__block-registrations {
+  list-style: none;
+  margin: 0.15rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+  width: 100%;
+}
+
+.spl-grid-cell__block-registration {
+  font-size: 0.55rem;
+  color: var(--sp-text);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ── Empty Cell ─────────────────────────────────────────── */
 
 .spl-cell--empty {

--- a/src/components/schedule-page/ui/scheduleGridCell.ts
+++ b/src/components/schedule-page/ui/scheduleGridCell.ts
@@ -78,6 +78,19 @@ function buildBlockedCell(data: ScheduleCellData): HTMLElement {
     label.appendChild(notesEl);
   }
 
+  const registrations = data.booking?.registrations ?? [];
+  if (registrations.length) {
+    const regsEl = document.createElement('ul');
+    regsEl.className = 'spl-grid-cell__block-registrations';
+    for (const entry of registrations) {
+      const item = document.createElement('li');
+      item.className = 'spl-grid-cell__block-registration';
+      item.textContent = entry;
+      regsEl.appendChild(item);
+    }
+    label.appendChild(regsEl);
+  }
+
   cell.appendChild(label);
   return cell;
 }

--- a/src/stories/schedule-page/ScheduleGridCell.stories.ts
+++ b/src/stories/schedule-page/ScheduleGridCell.stories.ts
@@ -45,6 +45,7 @@ import {
   PARTIAL_POTENTIAL,
   WITH_UMPIRE,
   BLOCKED_MAINTENANCE,
+  BLOCKED_PRACTICE_WITH_REGISTRATIONS,
   EMPTY_CELL,
   ALL_STATUSES,
   ALL_TEAMS,
@@ -55,6 +56,8 @@ import {
   ALL_TIME_MODIFIERS,
   ALL_GENDER_COLORS
 } from './cellData';
+
+import { within, expect } from 'storybook/test';
 
 export default {
   title: 'Schedule Page/Grid Cell',
@@ -538,6 +541,37 @@ export const BlockedCells = {
     const cells = ALL_BLOCKED.map((data) => labeledCell(data, data.booking?.bookingType || 'BLOCKED'));
     cells.push(labeledCell(EMPTY_CELL, 'Empty'));
     return gridLayout(cells, 'Blocked & Empty Cells');
+  }
+};
+
+// ============================================================================
+// PracticeWithRegistrations — PRACTICE booking + per-window participant list
+// ============================================================================
+
+export const PracticeWithRegistrations = {
+  name: 'Blocked / PRACTICE with registrations',
+  render: () => {
+    const root = document.createElement('div');
+    root.style.cssText = STORY_ROOT_STYLE;
+
+    const info = document.createElement('div');
+    info.style.cssText = STORY_INFO_STYLE;
+    info.textContent =
+      'PRACTICE blocks with registered participants — each registration is a pre-formatted string rendered as a list item under the bookingType label. The cell stays display-only; consumers (TMX) compose the strings (name + sub-window).';
+    root.appendChild(info);
+
+    const cell = cellWrapper(BLOCKED_PRACTICE_WITH_REGISTRATIONS, undefined, { width: '180px', height: '120px' });
+    root.appendChild(cell);
+
+    return root;
+  },
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const items = await canvas.findAllByRole('listitem');
+    expect(items.length).toBe(3);
+    expect(items[0].textContent).toBe('Smith / Jones (14:00–14:30)');
+    expect(items[1].textContent).toBe('Ortiz (14:30–15:00)');
+    expect(items[2].textContent).toBe('Park / Chen (15:00–15:30)');
   }
 };
 

--- a/src/stories/schedule-page/cellData.ts
+++ b/src/stories/schedule-page/cellData.ts
@@ -684,6 +684,17 @@ export const BLOCKED_GENERIC: ScheduleCellData = {
   booking: { bookingType: 'BLOCKED', rowCount: 1 }
 };
 
+export const BLOCKED_PRACTICE_WITH_REGISTRATIONS: ScheduleCellData = {
+  matchUpId: '',
+  isBlocked: true,
+  booking: {
+    bookingType: 'PRACTICE',
+    rowCount: 2,
+    notes: 'Open hitting',
+    registrations: ['Smith / Jones (14:00–14:30)', 'Ortiz (14:30–15:00)', 'Park / Chen (15:00–15:30)']
+  }
+};
+
 // ============================================================================
 // Empty Cell
 // ============================================================================
@@ -727,7 +738,12 @@ export const ALL_CONFLICTS: ScheduleCellData[] = [
 ];
 
 /** Blocked cells */
-export const ALL_BLOCKED: ScheduleCellData[] = [BLOCKED_MAINTENANCE, BLOCKED_PRACTICE, BLOCKED_GENERIC];
+export const ALL_BLOCKED: ScheduleCellData[] = [
+  BLOCKED_MAINTENANCE,
+  BLOCKED_PRACTICE,
+  BLOCKED_PRACTICE_WITH_REGISTRATIONS,
+  BLOCKED_GENERIC
+];
 
 /** Gender color demo — male, female, mixed in to-be-played and completed states */
 export const ALL_GENDER_COLORS: { data: ScheduleCellData; label: string }[] = [


### PR DESCRIPTION
First UI layer of practice court registration (factory schema landed
in tods-competition-factory `08abdf95`). `ScheduleCellData.booking`
gains an optional `registrations[]` of pre-formatted strings — the
cell renders each as a list item under the bookingType label so the
Now/Live strip can surface "who's on court 3 right now" beside the
PRACTICE marker.

Consumers (TMX) compose the registration strings (participant name +
sub-window). The cell stays display-only.

Adds Storybook story + play function asserting the list renders.

CI matrix green: 1390 vitest tests + lint + build clean.