### PR TITLE
fix(cards): exclude BYE matchUps from event/draw card completion counts

### DIFF
--- a/src/components/draw-card/__tests__/mapDraw.test.ts
+++ b/src/components/draw-card/__tests__/mapDraw.test.ts
@@ -1,0 +1,41 @@
+import { mapDrawDefinitionToCardData } from '../mapDraw';
+import { describe, it, expect } from 'vitest';
+
+describe('mapDrawDefinitionToCardData — matchUp counts', () => {
+  it('counts winningSide as completed and scheduled separately', () => {
+    const drawDefinition = {
+      drawId: 'd1',
+      structures: [
+        {
+          structureId: 's1',
+          matchUps: [
+            { matchUpId: 'm1', winningSide: 1 },
+            { matchUpId: 'm2', matchUpStatus: 'TO_BE_PLAYED', schedule: { scheduledTime: '08:00' } }
+          ]
+        }
+      ]
+    };
+    const out = mapDrawDefinitionToCardData(drawDefinition);
+    expect(out.matchUpCounts).toEqual({ total: 2, completed: 1, scheduled: 1, inProgress: 0 });
+  });
+
+  // Regression: BYE matchUps must NOT count toward total or completed.
+  it('excludes BYE matchUps from total and completed', () => {
+    const drawDefinition = {
+      drawId: 'd1',
+      structures: [
+        {
+          structureId: 's1',
+          matchUps: [
+            { matchUpId: 'b1', matchUpStatus: 'BYE' },
+            { matchUpId: 'b2', matchUpStatus: 'BYE' },
+            { matchUpId: 'm1', matchUpStatus: 'TO_BE_PLAYED', schedule: { scheduledTime: '08:00' } },
+            { matchUpId: 'm2', winningSide: 1 }
+          ]
+        }
+      ]
+    };
+    const out = mapDrawDefinitionToCardData(drawDefinition);
+    expect(out.matchUpCounts).toEqual({ total: 2, completed: 1, scheduled: 1, inProgress: 0 });
+  });
+});

--- a/src/components/draw-card/mapDraw.ts
+++ b/src/components/draw-card/mapDraw.ts
@@ -47,8 +47,12 @@ function countDrawMatchUps(drawDefinition: any): DrawMatchUpCounts {
   let scheduled = 0;
   let inProgress = 0;
   for (const matchUp of matchUps as any[]) {
+    // BYEs are not real matches — exclude them from BOTH the total and the
+    // completed count, otherwise a draw full of first-round byes reads as
+    // partially "played" before anyone has stepped on court.
+    if (matchUp?.matchUpStatus === 'BYE' || matchUp?.matchUpStatus === 'DOUBLE_BYE') continue;
     total += 1;
-    if (matchUp?.winningSide || matchUp?.matchUpStatus === 'BYE') completed += 1;
+    if (matchUp?.winningSide) completed += 1;
     else if (matchUp?.schedule?.scheduledTime) scheduled += 1;
     if (matchUp?.matchUpStatus === 'IN_PROGRESS') inProgress += 1;
   }

--- a/src/components/event-card/__tests__/mapEvent.test.ts
+++ b/src/components/event-card/__tests__/mapEvent.test.ts
@@ -66,6 +66,33 @@ describe('mapEventToCardData', () => {
     expect(out.matchUpCounts).toEqual({ total: 3, completed: 1, scheduled: 1, inProgress: 1 });
   });
 
+  // Regression: BYE matchUps must NOT count toward total or completed, otherwise a
+  // draw full of first-round byes reads as partially played before anyone steps on
+  // court (e.g. 64-draw with 38 entries → 26 byes showed 26/63 ≈ 41%).
+  it('excludes BYE matchUps from total and completed', () => {
+    const event = {
+      eventId: 'e1',
+      drawDefinitions: [
+        {
+          drawId: 'd1',
+          structures: [
+            {
+              structureId: 's1',
+              matchUps: [
+                { matchUpId: 'b1', matchUpStatus: 'BYE' },
+                { matchUpId: 'b2', matchUpStatus: 'BYE' },
+                { matchUpId: 'm1', matchUpStatus: 'TO_BE_PLAYED', schedule: { scheduledTime: '08:00' } },
+                { matchUpId: 'm2', winningSide: 1 }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+    const out = mapEventToCardData(event, { now: NOW });
+    expect(out.matchUpCounts).toEqual({ total: 2, completed: 1, scheduled: 1, inProgress: 0 });
+  });
+
   // Regression: Round Robin draws nest real matchUps in `structure.structures[].matchUps`
   // (CONTAINER -> ITEM groups). The hand-rolled walker only iterated
   // `draw.structures[].matchUps` and missed every RR matchUp; the factory's

--- a/src/components/event-card/mapEvent.ts
+++ b/src/components/event-card/mapEvent.ts
@@ -98,8 +98,13 @@ function countEventMatchUps(event: any): EventMatchUpCounts {
   let scheduled = 0;
   let inProgress = 0;
   for (const matchUp of matchUps as any[]) {
+    // BYEs are not real matches — exclude them from BOTH the total and the
+    // completed count, otherwise a draw full of first-round byes reads as
+    // partially "played" before anyone has stepped on court (e.g. a 64-draw
+    // with 38 entries shows 26/63 ≈ 41% with zero matches played).
+    if (matchUp?.matchUpStatus === 'BYE' || matchUp?.matchUpStatus === 'DOUBLE_BYE') continue;
     total += 1;
-    if (matchUp?.winningSide || matchUp?.matchUpStatus === 'BYE') completed += 1;
+    if (matchUp?.winningSide) completed += 1;
     else if (matchUp?.schedule?.scheduledTime) scheduled += 1;
     if (matchUp?.matchUpStatus === 'IN_PROGRESS') inProgress += 1;
   }


### PR DESCRIPTION
## Bug

The **event card** (and the **draw card**, same code) showed a completion rate of ~41% for a draw where **no matches had been played**. Reported on a 64-draw single-elimination with 38 entries.

## Root cause

`mapEvent.ts` / `mapDraw.ts` counted a matchUp as **completed** if it had a `winningSide` **or** `matchUpStatus === 'BYE'`, while `total` counted *every* matchUp including BYEs:

```ts
total += 1;
if (matchUp?.winningSide || matchUp?.matchUpStatus === 'BYE') completed += 1;
```

A 64-draw with 38 entries has 26 BYEs and 63 total matchUps → `26 / 63 ≈ 41%` before anyone steps on court.

## Fix

BYEs are not real matches — exclude them from **both** the total and the completed count; `completed` now counts `winningSide` only. For that draw the card now reads **0 / 37 = 0%**.

```ts
if (matchUp?.matchUpStatus === 'BYE' || matchUp?.matchUpStatus === 'DOUBLE_BYE') continue;
total += 1;
if (matchUp?.winningSide) completed += 1;
```

Applied to **both** the event card and the draw card (identical bug). The `createBracketTable` 'group fully decided' check that also treats byes as non-blocking is a *correct* boolean and was left as-is.

## Tests

- event-card `mapEvent`: new BYE-exclusion regression case.
- draw-card `mapDraw`: new test file (count + BYE exclusion).
- Full suite green (1439), lint + build clean.

## Delivery

courthive-components is consumed by TMX as a **published** dependency — this needs a courthive-components release, then a TMX dep bump + deploy to reach users.