### PR TITLE
feat(policy-catalog): add participant privacy editor

### DIFF
--- a/src/components/policy-catalog/controller/policyCatalogControl.ts
+++ b/src/components/policy-catalog/controller/policyCatalogControl.ts
@@ -9,6 +9,7 @@ import { RankingPointsEditorControl } from '../editors/ranking/rankingPointsEdit
 import { SchedulingEditorControl } from '../editors/scheduling/schedulingEditorControl';
 import { ScoringEditorControl } from '../editors/scoring/scoringEditorControl';
 import { SeedingEditorControl } from '../editors/seeding/seedingEditorControl';
+import { PrivacyEditorControl } from '../editors/privacy/privacyEditorControl';
 import { buildPolicyCatalogLayout } from '../ui/policyCatalogLayout';
 import { buildPolicyCatalogPanel } from '../ui/policyCatalogPanel';
 import { PolicyCatalogStore } from '../engine/policyCatalogStore';
@@ -18,6 +19,7 @@ import { buildJsonEditor } from '../ui/jsonEditor';
 import {
   POLICY_TYPE_SCHEDULING,
   POLICY_TYPE_RANKING_POINTS,
+  POLICY_TYPE_PARTICIPANT,
   POLICY_TYPE_SCORING,
   POLICY_TYPE_SEEDING,
 } from '../domain/policyDefaults';
@@ -133,6 +135,8 @@ export class PolicyCatalogControl {
       this.currentEditor = SeedingEditorControl.createEditorInstance(editorConfig);
     } else if (item.policyType === POLICY_TYPE_SCORING) {
       this.currentEditor = ScoringEditorControl.createEditorInstance(editorConfig);
+    } else if (item.policyType === POLICY_TYPE_PARTICIPANT) {
+      this.currentEditor = PrivacyEditorControl.createEditorInstance(editorConfig);
     } else {
       this.currentEditor = buildJsonEditor(editorConfig);
     }

--- a/src/components/policy-catalog/domain/policyDefaults.ts
+++ b/src/components/policy-catalog/domain/policyDefaults.ts
@@ -7,6 +7,7 @@ import { emptyRankingPolicy } from '../editors/ranking/domain/emptyRankingPolicy
 import { emptySchedulingPolicy } from '../editors/scheduling/domain/schedulingProjections';
 import { emptyScoringPolicy } from '../editors/scoring/domain/scoringProjections';
 import { emptySeedingPolicy } from '../editors/seeding/domain/seedingProjections';
+import { emptyPrivacyPolicy } from '../editors/privacy/domain/privacyProjections';
 
 // Policy type constants (mirrored from tods-competition-factory)
 export const POLICY_TYPE_SCHEDULING = 'scheduling';
@@ -119,7 +120,13 @@ export const POLICY_TYPE_METADATA: PolicyTypeMeta[] = [
   ),
 
   // Participants
-  meta(POLICY_TYPE_PARTICIPANT, 'Participant', 'Participant display and data rules', GROUP_PARTICIPANTS, false),
+  meta(
+    POLICY_TYPE_PARTICIPANT,
+    'Participant Privacy',
+    'Which participant details are published publicly',
+    GROUP_PARTICIPANTS,
+    true,
+  ),
 
   // Display & Audit
   meta(
@@ -143,6 +150,7 @@ export function getEmptyPolicyData(policyType: string): Record<string, unknown> 
   if (policyType === POLICY_TYPE_SCHEDULING) return emptySchedulingPolicy() as unknown as Record<string, unknown>;
   if (policyType === POLICY_TYPE_SCORING) return emptyScoringPolicy() as unknown as Record<string, unknown>;
   if (policyType === POLICY_TYPE_SEEDING) return emptySeedingPolicy() as unknown as Record<string, unknown>;
+  if (policyType === POLICY_TYPE_PARTICIPANT) return emptyPrivacyPolicy() as unknown as Record<string, unknown>;
   return {};
 }
 

--- a/src/components/policy-catalog/editors/privacy/domain/privacyProjections.ts
+++ b/src/components/policy-catalog/editors/privacy/domain/privacyProjections.ts
@@ -1,0 +1,85 @@
+/**
+ * Privacy editor domain — template-derived field enumeration + accessors.
+ *
+ * The field set and defaults come from the LIVE factory template
+ * (`fixtures.policies.POLICY_PRIVACY_DEFAULT`), so the editor stays complete if
+ * a newer factory schema adds privacy attributes — nothing is hardcoded.
+ */
+import { fixtures, factoryConstants } from 'tods-competition-factory';
+
+import type { PrivacyPolicyData } from '../types';
+
+const POLICY_TYPE_PARTICIPANT = factoryConstants.policyConstants.POLICY_TYPE_PARTICIPANT;
+
+export interface PrivacyFieldMeta {
+  field: string;
+  group: 'participant' | 'person';
+  /** Humanised label, e.g. birthDate → "Birth date". */
+  label: string;
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+/**
+ * A complete privacy policy in the catalog's INNER shape (no `[policyType]`
+ * wrapper) — matching how `safePolicyData` unwraps fixtures for every editor:
+ * `{ policyName, participant: { ...attributeFilter } }`.
+ */
+export function emptyPrivacyPolicy(): PrivacyPolicyData {
+  return clone(fixtures.policies.POLICY_PRIVACY_DEFAULT[POLICY_TYPE_PARTICIPANT]);
+}
+
+function root(policy: PrivacyPolicyData): any {
+  return policy?.participant ?? {};
+}
+
+function humanise(field: string): string {
+  const spaced = field.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/** All boolean attributes from the template — participant-level, then person. */
+export function privacyFields(): PrivacyFieldMeta[] {
+  const r = root(emptyPrivacyPolicy());
+  const participant: PrivacyFieldMeta[] = Object.keys(r)
+    .filter((k) => typeof r[k] === 'boolean')
+    .map((field) => ({ field, group: 'participant', label: humanise(field) }));
+  const person: PrivacyFieldMeta[] = Object.keys(r.person ?? {})
+    .filter((k) => typeof r.person[k] === 'boolean')
+    .map((field) => ({ field, group: 'person', label: humanise(field) }));
+  return [...participant, ...person];
+}
+
+export function readField(policy: PrivacyPolicyData, group: 'participant' | 'person', field: string): boolean {
+  const r = root(policy);
+  return group === 'person' ? !!r.person?.[field] : !!r[field];
+}
+
+/**
+ * Set an attribute on both the direct participant/person and the doubles/team
+ * `individualParticipants` branch, so singles and pair members stay consistent.
+ */
+export function writeField(
+  policy: PrivacyPolicyData,
+  group: 'participant' | 'person',
+  field: string,
+  value: boolean,
+): void {
+  const r = root(policy);
+  const setBoth = (primary: any, mirror: any) => {
+    if (primary && field in primary) primary[field] = value;
+    if (mirror && field in mirror) mirror[field] = value;
+  };
+  if (group === 'person') setBoth(r.person, r.individualParticipants?.person);
+  else setBoth(r, r.individualParticipants);
+}
+
+export function readPolicyName(policy: PrivacyPolicyData): string {
+  return policy?.policyName ?? '';
+}
+
+export function writePolicyName(policy: PrivacyPolicyData, value: string): void {
+  if (policy) policy.policyName = value;
+}

--- a/src/components/policy-catalog/editors/privacy/index.ts
+++ b/src/components/policy-catalog/editors/privacy/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Participant Privacy Editor — Public API
+ */
+
+export { PrivacyEditorControl, createPrivacyEditor } from './privacyEditorControl';
+export { PrivacyEditorStore } from './privacyEditorStore';
+export { buildPrivacyEditorPanel } from './privacyEditorPanel';
+export {
+  emptyPrivacyPolicy,
+  privacyFields,
+  readField,
+  writeField,
+  readPolicyName,
+  writePolicyName,
+} from './domain/privacyProjections';
+
+export type { PrivacyPolicyData, PrivacyEditorState, PrivacyEditorChangeListener, PrivacyEditorConfig } from './types';
+export type { PrivacyFieldMeta } from './domain/privacyProjections';

--- a/src/components/policy-catalog/editors/privacy/privacy-editor.css
+++ b/src/components/policy-catalog/editors/privacy/privacy-editor.css
@@ -1,0 +1,49 @@
+.privacy-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.privacy-editor__intro {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--chc-text-secondary, #555);
+}
+
+.privacy-editor__name {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-size: 0.8rem;
+  color: var(--chc-text-secondary, #555);
+}
+
+.privacy-editor__name input {
+  padding: 4px 8px;
+  border: 1px solid var(--chc-border-primary, #ccc);
+  border-radius: 4px;
+  font-size: 0.9rem;
+  background: var(--chc-bg-elevated, #fff);
+  color: var(--chc-text-primary, #363636);
+}
+
+.privacy-editor__group h4 {
+  margin: 6px 0;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--chc-text-primary, #363636);
+}
+
+.privacy-editor__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 4px 14px;
+}
+
+.privacy-editor__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.82rem;
+  cursor: pointer;
+}

--- a/src/components/policy-catalog/editors/privacy/privacyEditorControl.ts
+++ b/src/components/policy-catalog/editors/privacy/privacyEditorControl.ts
@@ -1,0 +1,76 @@
+/**
+ * Participant Privacy Editor Control — standalone controller (reusable without
+ * the catalog). Mirrors SeedingEditorControl.
+ */
+import { PrivacyEditorStore } from './privacyEditorStore';
+import { buildPrivacyEditorPanel } from './privacyEditorPanel';
+import type { PrivacyEditorConfig, PrivacyPolicyData } from './types';
+import type { PolicyEditorInstance as CatalogEditorInstance } from '../../types';
+
+export class PrivacyEditorControl {
+  private readonly store: PrivacyEditorStore;
+  private readonly panel: { element: HTMLElement; update: (state: any) => void };
+  private readonly unsubscribe: () => void;
+  private container: HTMLElement | null = null;
+
+  constructor(config: PrivacyEditorConfig) {
+    this.store = new PrivacyEditorStore(config);
+    this.panel = buildPrivacyEditorPanel(this.store, config);
+    this.unsubscribe = this.store.subscribe((state) => this.panel.update(state));
+    this.panel.update(this.store.getState());
+  }
+
+  render(container: HTMLElement): void {
+    this.container = container;
+    container.appendChild(this.panel.element);
+  }
+
+  destroy(): void {
+    this.unsubscribe();
+    if (this.container && this.panel.element.parentNode === this.container) {
+      this.container.removeChild(this.panel.element);
+    }
+    this.container = null;
+  }
+
+  getData(): PrivacyPolicyData {
+    return this.store.getData();
+  }
+
+  setData(data: PrivacyPolicyData): void {
+    this.store.setData(data);
+  }
+
+  getStore(): PrivacyEditorStore {
+    return this.store;
+  }
+
+  static createEditorInstance(config: {
+    initialData: Record<string, unknown>;
+    onChange: (data: Record<string, unknown>) => void;
+  }): CatalogEditorInstance {
+    const editorConfig: PrivacyEditorConfig = {
+      initialPolicy: config.initialData as PrivacyPolicyData,
+      onChange: (policy) => config.onChange(policy as Record<string, unknown>),
+    };
+    const control = new PrivacyEditorControl(editorConfig);
+    return {
+      element: control.panel.element,
+      setData(data: Record<string, unknown>) {
+        control.setData(data as PrivacyPolicyData);
+      },
+      getData() {
+        return control.getData() as Record<string, unknown>;
+      },
+      destroy() {
+        control.destroy();
+      },
+    };
+  }
+}
+
+export function createPrivacyEditor(config: PrivacyEditorConfig, container: HTMLElement): PrivacyEditorControl {
+  const control = new PrivacyEditorControl(config);
+  control.render(container);
+  return control;
+}

--- a/src/components/policy-catalog/editors/privacy/privacyEditorPanel.ts
+++ b/src/components/policy-catalog/editors/privacy/privacyEditorPanel.ts
@@ -1,0 +1,73 @@
+/**
+ * Participant Privacy Editor — panel. Renders the policy name plus grouped
+ * publish/strip toggles (person details, participant details) derived from the
+ * factory template. Returns { element, update } like the other editors.
+ */
+import { privacyFields, readField, readPolicyName } from './domain/privacyProjections';
+import type { PrivacyEditorStore } from './privacyEditorStore';
+import type { PrivacyEditorConfig, PrivacyEditorState } from './types';
+
+export function buildPrivacyEditorPanel(
+  store: PrivacyEditorStore,
+  _config: PrivacyEditorConfig,
+): { element: HTMLElement; update: (state: PrivacyEditorState) => void } {
+  const element = document.createElement('div');
+  element.className = 'privacy-editor';
+
+  const intro = document.createElement('p');
+  intro.className = 'privacy-editor__intro';
+  intro.textContent = 'Choose which participant details are published publicly. Unchecked = kept private.';
+  element.appendChild(intro);
+
+  const nameRow = document.createElement('label');
+  nameRow.className = 'privacy-editor__name';
+  const nameLabel = document.createElement('span');
+  nameLabel.textContent = 'Policy name';
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.placeholder = 'e.g. Public roster privacy';
+  nameInput.addEventListener('input', () => store.setPolicyName(nameInput.value));
+  nameRow.append(nameLabel, nameInput);
+  element.appendChild(nameRow);
+
+  const fields = privacyFields();
+  const checkboxes = new Map<string, HTMLInputElement>();
+
+  const buildGroup = (group: 'person' | 'participant', title: string): void => {
+    const section = document.createElement('section');
+    section.className = 'privacy-editor__group';
+    const heading = document.createElement('h4');
+    heading.textContent = title;
+    section.appendChild(heading);
+
+    const grid = document.createElement('div');
+    grid.className = 'privacy-editor__grid';
+    for (const meta of fields.filter((f) => f.group === group)) {
+      const row = document.createElement('label');
+      row.className = 'privacy-editor__toggle';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.addEventListener('change', () => store.setField(group, meta.field, cb.checked));
+      const text = document.createElement('span');
+      text.textContent = meta.label;
+      row.append(cb, text);
+      grid.appendChild(row);
+      checkboxes.set(`${group}.${meta.field}`, cb);
+    }
+    section.appendChild(grid);
+    element.appendChild(section);
+  };
+
+  buildGroup('person', 'Person details');
+  buildGroup('participant', 'Participant details');
+
+  const update = (state: PrivacyEditorState): void => {
+    nameInput.value = readPolicyName(state.draft);
+    for (const meta of fields) {
+      const cb = checkboxes.get(`${meta.group}.${meta.field}`);
+      if (cb) cb.checked = readField(state.draft, meta.group, meta.field);
+    }
+  };
+
+  return { element, update };
+}

--- a/src/components/policy-catalog/editors/privacy/privacyEditorStore.ts
+++ b/src/components/policy-catalog/editors/privacy/privacyEditorStore.ts
@@ -1,0 +1,62 @@
+/**
+ * Participant Privacy Editor — Observable store. Mirrors SeedingEditorStore.
+ */
+import { emptyPrivacyPolicy, writeField, writePolicyName } from './domain/privacyProjections';
+import type { PrivacyEditorChangeListener, PrivacyEditorConfig, PrivacyEditorState, PrivacyPolicyData } from './types';
+
+function deepClone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+export class PrivacyEditorStore {
+  private state: PrivacyEditorState;
+  private readonly listeners: Set<PrivacyEditorChangeListener> = new Set();
+  private readonly config: PrivacyEditorConfig;
+
+  constructor(config: PrivacyEditorConfig) {
+    this.config = config;
+    this.state = { draft: deepClone(config.initialPolicy ?? emptyPrivacyPolicy()), dirty: false };
+  }
+
+  getState(): PrivacyEditorState {
+    return this.state;
+  }
+
+  getData(): PrivacyPolicyData {
+    return deepClone(this.state.draft);
+  }
+
+  setData(data: PrivacyPolicyData): void {
+    this.state = { ...this.state, draft: deepClone(data), dirty: false };
+    this.emit();
+  }
+
+  setPolicyName(value: string): void {
+    const draft = deepClone(this.state.draft);
+    writePolicyName(draft, value);
+    this.commitDraft(draft);
+  }
+
+  setField(group: 'participant' | 'person', field: string, value: boolean): void {
+    const draft = deepClone(this.state.draft);
+    writeField(draft, group, field, value);
+    this.commitDraft(draft);
+  }
+
+  subscribe(listener: PrivacyEditorChangeListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private commitDraft(draft: PrivacyPolicyData): void {
+    this.state = { ...this.state, draft, dirty: true };
+    this.emit();
+    this.config.onChange?.(deepClone(draft));
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) listener(this.state);
+  }
+}

--- a/src/components/policy-catalog/editors/privacy/types.ts
+++ b/src/components/policy-catalog/editors/privacy/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Participant Privacy Policy Editor — Type Definitions
+ *
+ * Edits a factory `POLICY_TYPE_PARTICIPANT` attribute-filter policy (see
+ * factory/src/fixtures/policies/POLICY_PRIVACY_DEFAULT.ts): each attribute is
+ * `true` (published to public payloads) or `false` (stripped). policyData is the
+ * full factory policy shape so it can be attached to a tournamentRecord and
+ * consumed by the factory directly.
+ */
+
+// Full factory policy shape: { participant: { policyName, participant: {...} } }.
+export type PrivacyPolicyData = Record<string, any>;
+
+export interface PrivacyEditorState {
+  draft: PrivacyPolicyData;
+  dirty: boolean;
+}
+
+export type PrivacyEditorChangeListener = (state: PrivacyEditorState) => void;
+
+export interface PrivacyEditorConfig {
+  initialPolicy?: PrivacyPolicyData;
+  onChange?: (policy: PrivacyPolicyData) => void;
+}

--- a/src/components/policy-catalog/index.ts
+++ b/src/components/policy-catalog/index.ts
@@ -99,6 +99,20 @@ export type {
 } from './editors/scoring';
 
 // ============================================================================
+// Participant Privacy Editor (re-export standalone)
+// ============================================================================
+
+export {
+  PrivacyEditorControl,
+  createPrivacyEditor,
+  PrivacyEditorStore,
+  buildPrivacyEditorPanel,
+  emptyPrivacyPolicy,
+  privacyFields,
+} from './editors/privacy';
+export type { PrivacyPolicyData, PrivacyEditorConfig, PrivacyFieldMeta } from './editors/privacy';
+
+// ============================================================================
 // Types
 // ============================================================================
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -577,6 +577,7 @@ export type {
 // Policy Catalog
 import './components/policy-catalog/ui/policy-catalog.css';
 import './components/policy-catalog/editors/scheduling/scheduling-editor.css';
+import './components/policy-catalog/editors/privacy/privacy-editor.css';
 export {
   PolicyCatalogControl,
   PolicyCatalogStore,


### PR DESCRIPTION
Fifth policy-catalog editor for `POLICY_TYPE_PARTICIPANT` (Participant Privacy). 1446 tests green. courthive-ams consumes this as `^3.5.0`.