### PR TITLE
fix(deps): bump tods-competition-factory to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "focus-trap": "^8.0.0",
     "timepicker-ui": "^4.1.2",
     "tippy.js": "6.3.7",
-    "tods-competition-factory": "6.0.0",
+    "tods-competition-factory": "6.0.2",
     "vanillajs-datepicker": "1.3.4"
   }
 }


### PR DESCRIPTION
Bump tods-competition-factory to 6.0.2 (latest — bug fixes).