### PR TITLE
feat(schedule-page): add isPublished flag to ScheduleDate

### DIFF
--- a/src/components/schedule-page/types.ts
+++ b/src/components/schedule-page/types.ts
@@ -57,6 +57,8 @@ export interface CatalogMatchUpItem {
 export interface ScheduleDate {
   date: string;
   isActive: boolean;
+  /** Order of play for this date is published (drives the selector publish cue). */
+  isPublished?: boolean;
   matchUpCount?: number;
   issueCount?: number;
 }


### PR DESCRIPTION
Adds an optional `isPublished` boolean to the `ScheduleDate` type.

Consumed by TMX's schedule date selector to render a per-date order-of-play
"published" cue (green dot on the button + popover chips, and a "Published"
status line). The field is optional and additive — no behavior change for
existing consumers.

TMX depends on this: its `feat/schedule-publish-policy-ux` branch references
`ScheduleDate.isPublished`, so this needs to release (→ 3.8.0) before that TMX
PR can pass CI.
