### PR TITLE
feat(burst): elimination-structure selection + round-robin guard for the sunburst

### DIFF
--- a/src/components/burstChart/__tests__/progressionStructure.test.ts
+++ b/src/components/burstChart/__tests__/progressionStructure.test.ts
@@ -1,0 +1,58 @@
+import { fromFactoryDrawData, pickProgressionStructure } from '../matchUpTransform';
+import { describe, expect, it } from 'vitest';
+
+// Enriched-structure shapes mirroring getEventData().drawsData[i].structures[j]:
+// round-robin → finishingPosition WIN_RATIO + structureType CONTAINER;
+// elimination → finishingPosition ROUND_OUTCOME.
+const rrMain = { stage: 'MAIN', finishingPosition: 'WIN_RATIO', structureType: 'CONTAINER' };
+const rrQualifying = { stage: 'QUALIFYING', finishingPosition: 'WIN_RATIO', structureType: 'CONTAINER' };
+const seMain = { stage: 'MAIN', finishingPosition: 'ROUND_OUTCOME', roundMatchUps: { 1: [], 2: [] } };
+const playOff = { stage: 'PLAY_OFF', finishingPosition: 'ROUND_OUTCOME', roundMatchUps: { 1: [] } };
+const consolation = { stage: 'CONSOLATION', finishingPosition: 'ROUND_OUTCOME' };
+
+describe('pickProgressionStructure', () => {
+  it('returns the MAIN single-elimination structure for a plain SE draw', () => {
+    expect(pickProgressionStructure([seMain])).toBe(seMain);
+  });
+
+  it('picks the MAIN elimination structure over an RR qualifying structure', () => {
+    expect(pickProgressionStructure([rrQualifying, seMain])).toBe(seMain);
+  });
+
+  it('picks the playoff bracket when MAIN is round-robin (RR + playoff)', () => {
+    expect(pickProgressionStructure([rrMain, playOff])).toBe(playOff);
+  });
+
+  it('returns undefined for a pure round-robin draw (no elimination bracket)', () => {
+    expect(pickProgressionStructure([rrMain])).toBeUndefined();
+  });
+
+  it('prefers MAIN over other elimination structures (e.g. consolation)', () => {
+    expect(pickProgressionStructure([seMain, consolation])).toBe(seMain);
+  });
+
+  it('returns undefined for empty / missing input', () => {
+    expect(pickProgressionStructure([])).toBeUndefined();
+    expect(pickProgressionStructure(undefined)).toBeUndefined();
+  });
+});
+
+describe('fromFactoryDrawData round-robin guard', () => {
+  it('returns empty data for a round-robin structure (never a force-fit bracket)', () => {
+    const rrWithRounds = {
+      finishingPosition: 'WIN_RATIO',
+      structureType: 'CONTAINER',
+      roundMatchUps: { 1: [], 2: [], 3: [] }
+    };
+    expect(fromFactoryDrawData(rrWithRounds)).toEqual({ drawSize: 0, roundMatchUps: {} });
+  });
+
+  it('still transforms a structure without finishingPosition (legacy / hand-built)', () => {
+    // Backward-compat: the guard rejects only DEFINITE round-robin, so an
+    // ambiguous structure (no finishingPosition) transforms as before.
+    const legacyLike = { roundMatchUps: { 1: [{ winningSide: 1, sides: [] }] } };
+    const result = fromFactoryDrawData(legacyLike);
+    expect(result.drawSize).toBe(2);
+    expect(Object.keys(result.roundMatchUps)).toEqual(['1']);
+  });
+});

--- a/src/components/burstChart/matchUpTransform.ts
+++ b/src/components/burstChart/matchUpTransform.ts
@@ -7,11 +7,43 @@
  * - fromLegacyDraw: legacy TournamentDraw JSON (R128/R64/.../W) → SunburstDrawData
  */
 
-import { entryStatusConstants } from 'tods-competition-factory';
+import { drawDefinitionConstants, entryStatusConstants } from 'tods-competition-factory';
 import { competitivenessForMatchUp } from './competitiveness';
 import type { SunburstDrawData, SunburstMatchUp, SunburstSide } from './burstChart';
 
 const { LUCKY_LOSER, WILDCARD, QUALIFIER } = entryStatusConstants;
+const { WIN_RATIO, ROUND_OUTCOME, MAIN, CONTAINER } = drawDefinitionConstants;
+
+// The sunburst is a single-elimination bracket: it assumes each round halves.
+// Only a `ROUND_OUTCOME` (elimination) structure has that progression; a
+// round-robin structure (`finishingPosition: WIN_RATIO`, `structureType:
+// CONTAINER`) does not — force-fitting its non-halving rounds into a bracket
+// lumps in every RR matchUp unconnected.
+function isEliminationStructure(structure: any): boolean {
+  return structure?.finishingPosition === ROUND_OUTCOME && structure?.structureType !== CONTAINER;
+}
+
+// Only DEFINITE round-robin structures are rejected by the transform guard, so a
+// structure lacking `finishingPosition` (legacy / hand-built fixtures) still
+// transforms as before — the guard never blanks an ambiguous input.
+function isRoundRobinStructure(structure: any): boolean {
+  return structure?.finishingPosition === WIN_RATIO || structure?.structureType === CONTAINER;
+}
+
+/**
+ * Pick the structure the progression sunburst should render from a draw's
+ * `getEventData().drawsData[i].structures`. A composite draw (round-robin
+ * qualifying → single-elimination main, or round-robin main → elimination
+ * playoff) must render its ELIMINATION structure, never the round-robin one.
+ * Returns the elimination structure (MAIN preferred, else the first), or
+ * `undefined` when the draw has no bracket (pure round-robin).
+ */
+export function pickProgressionStructure(structures?: any[]): any | undefined {
+  if (!structures?.length) return undefined;
+  const elimination = structures.filter(isEliminationStructure);
+  if (!elimination.length) return undefined;
+  return elimination.find((structure: any) => structure.stage === MAIN) ?? elimination[0];
+}
 
 // ============================================================================
 // fromFactoryDrawData — tods-competition-factory → SunburstDrawData
@@ -22,6 +54,14 @@ const { LUCKY_LOSER, WILDCARD, QUALIFIER } = entryStatusConstants;
  * object into the TODS-aligned SunburstDrawData that the sunburst consumes.
  */
 export function fromFactoryDrawData(structure: any): SunburstDrawData {
+  // Defensive: a round-robin (non-bracket) structure passed in directly renders
+  // nothing rather than force-fitting its rounds into a bracket. Consumers should
+  // select the bracket via `pickProgressionStructure`; this backstops a naive
+  // `structures[0]` call.
+  if (isRoundRobinStructure(structure)) {
+    return { drawSize: 0, roundMatchUps: {} };
+  }
+
   const roundMatchUps: Record<number, SunburstMatchUp[]> = {};
 
   for (const [roundNum, matchUps] of Object.entries(structure.roundMatchUps)) {
@@ -151,11 +191,7 @@ function buildWinnerSets(
   return winnerSets;
 }
 
-function resolveWinningSide(
-  name1: string,
-  name2: string,
-  winners: Set<string>
-): number | undefined {
+function resolveWinningSide(name1: string, name2: string, winners: Set<string>): number | undefined {
   const isBye = name1 === 'BYE' || name2 === 'BYE';
   if (isBye) {
     return name1 === 'BYE' ? 2 : 1;

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,7 +340,11 @@ export type {
   BurstChartOptions,
   BurstChartInstance
 } from './components/burstChart/burstChart';
-export { fromFactoryDrawData, fromLegacyDraw } from './components/burstChart/matchUpTransform';
+export {
+  fromFactoryDrawData,
+  fromLegacyDraw,
+  pickProgressionStructure
+} from './components/burstChart/matchUpTransform';
 export {
   competitivenessColor,
   getCompetitivenessBand,


### PR DESCRIPTION
## What
Moves the composite-draw fix (shipped consumer-side in CourtHive/TMX#1223) into the burst chart itself, so every consumer (TMX, courthive-public, …) gets correct behavior.

The progression sunburst is a single-elimination bracket (it assumes each round halves). For a composite draw — **round-robin qualifying → single-elimination main**, or **round-robin main → elimination playoff** — a naive `structures[0]` pick feeds the round-robin structure in, force-fitting its non-halving rounds into a bracket and lumping every RR matchUp in unconnected.

## Changes (`matchUpTransform.ts`)
- **`pickProgressionStructure(structures)`** — new export. Selects the elimination structure (`finishingPosition: ROUND_OUTCOME`; `MAIN` preferred, else the first), or `undefined` when the draw has no bracket (pure round-robin).
- **`fromFactoryDrawData` guard** — a *definite* round-robin structure (`WIN_RATIO` / `CONTAINER`) now returns empty data (`{ drawSize: 0, roundMatchUps: {} }`) instead of a force-fit bracket. Structures lacking `finishingPosition` (legacy / hand-built fixtures) still transform exactly as before — the guard never blanks an ambiguous input.

## Verification
- Full suite **1476** tests pass (no regression); new `progressionStructure.test.ts` — 8 cases (selection + guard + backward-compat).
- `pnpm build` clean; `eslint` clean on touched files.
- Discriminator (`finishingPosition` ROUND_OUTCOME vs WIN_RATIO, structureType CONTAINER) verified empirically against the factory.

## Follow-up (not in this PR)
- No publish here — merging just **stages** the release-please PR. Publish can batch with the `renderForm` opt-in `<form>` task (already in Mentat/TASKS.md) or go standalone.
- On publish: bump TMX's `courthive-components` dep and drop TMX's local `pickProgressionStructure` (the duplicate in TMX#1223).