### PR TITLE
feat(forms): opt-in <form> mode on renderForm (password managers + Enter-to-submit)

### DIFF
--- a/src/components/forms/renderForm.ts
+++ b/src/components/forms/renderForm.ts
@@ -10,6 +10,10 @@
  * @param elem - Container element where the form will be rendered
  * @param items - Array of field configuration objects (see ITEM PROPERTIES below)
  * @param relationships - Optional array of field relationships for validation and events
+ * @param options - Optional. `{ form }` wraps the fields in a real `<form>` with a
+ *   visually-hidden submit button so password managers and native Enter-to-submit
+ *   have an unambiguous target; `form.onSubmit({ e, inputs, fields })` runs on submit.
+ *   Default (omitted) keeps the historical `<div>` container.
  * @returns Object containing all input elements keyed by field name
  *
  * ============================================================================
@@ -158,6 +162,22 @@
  * ]);
  *
  * @example
+ * // Form mode — real <form> so 1Password / Enter submit deterministically.
+ * // The modal's visible Login/Cancel buttons live in the footer; this hidden
+ * // submit is only the keyboard/password-manager target.
+ * const inputs = renderForm(elem, [
+ *   { label: 'Email', field: 'email', type: 'email', autocomplete: 'email' },
+ *   { label: 'Password', field: 'password', type: 'password', autocomplete: 'current-password' }
+ * ], relationships, {
+ *   form: {
+ *     onSubmit: () => {
+ *       if (!emailValidator(inputs.email.value) || !inputs.password.value) return;
+ *       submitCredentials();
+ *     }
+ *   }
+ * });
+ *
+ * @example
  * // Form with mixed item types
  * const inputs = renderForm(container, [
  *   { text: '<h3>User Registration</h3>', header: true },
@@ -172,10 +192,23 @@ import { DateRangePicker } from 'vanillajs-datepicker';
 import { isFunction } from '../../helpers/typeOf';
 import { renderField } from './renderField';
 
-export function renderForm(elem: HTMLElement, items: any[], relationships?: any[]): any {
-  const div = document.createElement('div');
-  div.style.cssText = 'display: flex; flex-direction: column; width: 100%;';
-  div.classList.add('flexcol');
+export interface RenderFormOptions {
+  /**
+   * Wrap the fields in a real `<form>` so password managers and native
+   * Enter-to-submit have an unambiguous target. `true` uses defaults; pass an
+   * object to wire an `onSubmit` handler. Omitted (the default) keeps the
+   * historical `<div>` container, so existing callers are unaffected.
+   */
+  form?: boolean | { onSubmit?: (args: { e: Event; inputs: any; fields: any }) => void };
+}
+
+export function renderForm(elem: HTMLElement, items: any[], relationships?: any[], options?: RenderFormOptions): any {
+  const useForm = !!options?.form;
+  const formConfig = (typeof options?.form === 'object' && options.form) || {};
+
+  const container = document.createElement(useForm ? 'form' : 'div');
+  container.style.cssText = `display: flex; flex-direction: column; width: 100%;${useForm ? ' margin: 0;' : ''}`;
+  container.classList.add('flexcol');
 
   const inputs: any = {},
     fields: any = {};
@@ -184,13 +217,13 @@ export function renderForm(elem: HTMLElement, items: any[], relationships?: any[
 
   for (const item of items) {
     if ((item.text || item.html) && !item.field) {
-      focus = renderTextItem(item, div, inputs, fields, focus);
+      focus = renderTextItem(item, container, inputs, fields, focus);
       continue;
     }
     if (item.divider) {
       const hr = document.createElement('hr');
       hr.classList.add('dropdown-divider');
-      div.appendChild(hr);
+      container.appendChild(hr);
       continue;
     }
     if (item.spacer) {
@@ -200,24 +233,51 @@ export function renderForm(elem: HTMLElement, items: any[], relationships?: any[
         (typeof item.spacer === 'string' && item.spacer) ||
         `1em`;
       spacer.style.marginBlockEnd = spaceValue;
-      div.appendChild(spacer);
+      container.appendChild(spacer);
       continue;
     }
     if ((!item.label && !item.field) || item.hide) continue;
 
     if (item.field) {
-      focus = renderFieldItem(item, div, inputs, fields, focus);
+      focus = renderFieldItem(item, container, inputs, fields, focus);
     }
   }
   if (focus) setTimeout(() => focus!.focus(), 200);
 
-  elem.appendChild(div);
+  if (useForm) attachFormSubmit(container as HTMLFormElement, formConfig, inputs, fields);
+
+  elem.appendChild(container);
 
   if (relationships?.length) {
     applyRelationships(relationships, items, inputs, fields);
   }
 
   return inputs;
+}
+
+// A real submit control is what makes native Enter submit the form and what
+// password managers target. It's visually hidden — a form-mode caller's visible
+// actions typically live elsewhere (e.g. a modal footer). The submit handler
+// preventDefaults and routes to the caller's onSubmit with the same
+// `{ e, inputs, fields }` shape relationship handlers receive.
+function attachFormSubmit(
+  form: HTMLFormElement,
+  config: { onSubmit?: (args: { e: Event; inputs: any; fields: any }) => void },
+  inputs: any,
+  fields: any
+): void {
+  const submit = document.createElement('button');
+  submit.type = 'submit';
+  submit.tabIndex = -1;
+  submit.setAttribute('aria-hidden', 'true');
+  submit.style.cssText =
+    'position:absolute;width:1px;height:1px;padding:0;border:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);';
+  form.appendChild(submit);
+
+  form.addEventListener('submit', (e: Event) => {
+    e.preventDefault();
+    config.onSubmit?.({ e, inputs, fields });
+  });
 }
 
 function renderPairedField(

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,6 +312,7 @@ import './components/forms/styles';
 export { renderButtons } from './components/forms/renderButtons';
 export { renderField, renderOptions } from './components/forms/renderField';
 export { renderForm } from './components/forms/renderForm';
+export type { RenderFormOptions } from './components/forms/renderForm';
 export { renderMenu } from './components/forms/renderMenu';
 export { validator } from './components/forms/renderValidator';
 

--- a/src/stories/RenderFormFormMode.stories.ts
+++ b/src/stories/RenderFormFormMode.stories.ts
@@ -1,0 +1,79 @@
+/**
+ * renderForm — opt-in `<form>` mode — play-function tests.
+ *
+ * The DOM/interaction layer for courthive-components is Storybook play
+ * functions + `test-storybook` (never happy-dom). Verifies that:
+ *   - default (no options) still renders a plain `<div>` container;
+ *   - `{ form }` renders a real `<form>` with a visually-hidden submit button;
+ *   - native Enter (a password manager's fill-and-submit path) fires onSubmit
+ *     with the entered values.
+ *
+ * Run interactively: `pnpm storybook`
+ * Run as tests:      `pnpm storybook` (one terminal) +
+ *                    `pnpm test-storybook -- --testPathPatterns RenderFormFormMode`
+ */
+import type { Meta, StoryObj } from '@storybook/html-vite';
+import { expect, fn, userEvent } from 'storybook/test';
+import { renderForm } from '../components/forms/renderForm';
+
+const meta: Meta = {
+  title: 'Renderers/Form/Tests/formMode'
+};
+export default meta;
+
+const FIELDS = [
+  { label: 'Email', field: 'email', type: 'email', autocomplete: 'email', placeholder: 'you@example.com' },
+  { label: 'Password', field: 'password', type: 'password', autocomplete: 'current-password' }
+];
+
+function mount(options?: any): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.style.cssText = 'padding: 24px; max-width: 360px;';
+  renderForm(wrap, FIELDS, undefined, options);
+  return wrap;
+}
+
+export const DefaultRendersDiv: StoryObj = {
+  name: 'no options → container is a <div>, no <form> and no submit button',
+  render: () => mount(),
+  play: async ({ canvasElement }) => {
+    expect(canvasElement.querySelector('form')).toBeNull();
+    expect(canvasElement.querySelector('button[type="submit"]')).toBeNull();
+  }
+};
+
+export const FormModeRendersForm: StoryObj = {
+  name: 'form mode → real <form> with a visually-hidden submit button',
+  render: () => mount({ form: true }),
+  play: async ({ canvasElement }) => {
+    const form = canvasElement.querySelector('form');
+    expect(form).not.toBeNull();
+    expect(form?.classList.contains('flexcol')).toBe(true);
+
+    const submit = form?.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(submit).not.toBeNull();
+    expect(submit.getAttribute('aria-hidden')).toBe('true');
+    expect(submit.tabIndex).toBe(-1);
+    // Visually clipped — not a visible action (those live in the modal footer).
+    expect(submit.style.position).toBe('absolute');
+  }
+};
+
+export const FormModeSubmitFiresOnSubmit: StoryObj = {
+  name: 'native Enter fires onSubmit with the entered inputs',
+  args: { onSubmit: fn() },
+  render: (args: any) => mount({ form: { onSubmit: args.onSubmit } }),
+  play: async ({ canvasElement, args }: any) => {
+    const email = canvasElement.querySelector('input[type="email"]') as HTMLInputElement;
+    const password = canvasElement.querySelector('input[type="password"]') as HTMLInputElement;
+
+    await userEvent.type(email, 'player@example.com');
+    // Enter in a field of a form that has a submit button submits the form.
+    await userEvent.type(password, 'secret{Enter}');
+
+    expect(args.onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = args.onSubmit.mock.calls[0][0];
+    expect(submitted.inputs.email.value).toBe('player@example.com');
+    expect(submitted.inputs.password.value).toBe('secret');
+  }
+};


### PR DESCRIPTION
## Why
`renderForm` renders a `<div>`, so login modals hand-rolled from it have no real `<form>` — password managers (1Password) have nothing to bind to and native Enter doesn't submit. Two apps patched this **per-app** by wrapping `renderForm`'s output in a bespoke `<form>` + hidden submit + `onsubmit` (TMX [#1217](https://github.com/CourtHive/TMX/pull/1217), courthive-ams [#82](https://github.com/CourtHive/courthive-ams/pull/82)). This lifts that into the shared primitive.

## What
New **opt-in 4th arg** `options?: { form }` (backward-compatible — omitted keeps the historical `<div>`, so every existing caller is unaffected):
- `form: true | { onSubmit }` renders the fields inside a real `<form class="flexcol">`.
- Adds a **visually-hidden** submit button (`type=submit`, `aria-hidden`, `tabIndex=-1`, clipped) — the keyboard/password-manager target; the modal's visible actions stay in its footer.
- On submit (native Enter, a password manager's fill-and-submit, or `requestSubmit()`) it `preventDefault`s and calls `form.onSubmit({ e, inputs, fields })` — same arg shape as relationship handlers.
- Exports the `RenderFormOptions` type.

## Verification
- **Storybook play functions** (`RenderFormFormMode.stories.ts`, run via `test-storybook` — the sanctioned components DOM layer): default stays a `<div>` (no form/submit); form mode renders a real `<form>` + hidden aria-hidden submit; **native Enter fires onSubmit with the entered values**. 3/3 pass in chromium.
- `pnpm build` clean, `eslint` clean, full **vitest suite 1476** green (no regression — div default preserved).

## Batched release
Joins the staged release-please PR (**3.10.0**, already includes the burst structure-selection work [#473](https://github.com/CourtHive/courthive-components/pull/473)). On publish, the cascade migrates TMX + courthive-ams login modals to `{ form }` and deletes the per-app boilerplate — see `Mentat/TASKS.md`.