### PR TITLE
docs(forms): document renderForm opt-in <form> mode

### DIFF
--- a/src/components/forms/README.md
+++ b/src/components/forms/README.md
@@ -198,6 +198,32 @@ const inputs = renderForm(
 );
 ```
 
+**Form Mode (`<form>` wrapper for password managers + Enter-to-submit):**
+
+By default `renderForm` renders a `<div>`. Pass a 4th `options` argument with `form` to wrap the fields in
+a real `<form>` — password managers (1Password, etc.) bind to it and native <kbd>Enter</kbd> submits. A
+visually-hidden submit button is the keyboard/password-manager target, so a modal's visible actions can stay
+in its footer. `form.onSubmit({ e, inputs, fields })` runs on submit (after `preventDefault`).
+
+```typescript
+const inputs = renderForm(
+  container,
+  [
+    { label: 'Email', field: 'email', type: 'email', autocomplete: 'email' },
+    { label: 'Password', field: 'password', type: 'password', autocomplete: 'current-password' }
+  ],
+  relationships,
+  {
+    form: {
+      onSubmit: () => {
+        if (!emailValidator(inputs.email.value) || !inputs.password.value) return;
+        submitCredentials();
+      }
+    }
+  }
+);
+```
+
 **See:** [renderForm.stories.ts](../../stories/renderForm.stories.ts) for complete form examples
 
 ---

--- a/src/stories/renderForm.stories.ts
+++ b/src/stories/renderForm.stories.ts
@@ -6,11 +6,12 @@ const { MALE, FEMALE } = genderConstants;
 
 const PLACEHOLDER_DATE = 'YYYY-MM-DD';
 const PLACEHOLDER_EMAIL = 'john@example.com';
+const ICON_EMAIL = 'fas fa-envelope';
 
 export default {
   title: 'Renderers/Form',
   tags: ['autodocs'],
-  render: ({ title, items, relationships }) => {
+  render: ({ title, items, relationships, options }) => {
     const wrapper = document.createElement('div');
     wrapper.style.maxWidth = '600px';
     wrapper.style.margin = '20px';
@@ -69,7 +70,7 @@ export default {
     wrapper.appendChild(style);
     wrapper.appendChild(container);
 
-    const inputs = renderForm(container, items, relationships);
+    const inputs = renderForm(container, items, relationships, options);
 
     // Add submit button to demonstrate form values
     const submitBtn = document.createElement('button');
@@ -196,7 +197,7 @@ export const RegistrationForm = {
         field: 'email',
         type: 'email',
         placeholder: PLACEHOLDER_EMAIL,
-        iconLeft: 'fas fa-envelope',
+        iconLeft: ICON_EMAIL,
         validator: (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value),
         error: 'Please enter a valid email'
       },
@@ -505,7 +506,7 @@ export const CompleteExample = {
         field: 'email',
         type: 'email',
         placeholder: PLACEHOLDER_EMAIL,
-        iconLeft: 'fas fa-envelope',
+        iconLeft: ICON_EMAIL,
         fieldPair: {
           label: 'Phone',
           field: 'phone',
@@ -545,6 +546,44 @@ export const CompleteExample = {
         id: 'rulesCheck',
         checkbox: true,
         checked: false
+      }
+    ]
+  }
+};
+
+/**
+ * Form mode — `options.form` wraps the fields in a real `<form>` so password
+ * managers (1Password, …) bind to it and native Enter submits. A visually-hidden
+ * submit button is the keyboard/password-manager target; `onSubmit` fires on
+ * Enter or a password manager's fill-and-submit. (Try: type into the fields and
+ * press Enter.)
+ */
+export const FormMode = {
+  args: {
+    title: 'Login (form mode)',
+    options: {
+      form: {
+        onSubmit: ({ inputs }: any) =>
+          alert(`Submitted via <form> (Enter / password manager) — email: ${inputs.email.value}`)
+      }
+    },
+    items: [
+      {
+        label: 'Email',
+        field: 'email',
+        type: 'email',
+        placeholder: PLACEHOLDER_EMAIL,
+        iconLeft: ICON_EMAIL,
+        autocomplete: 'email',
+        focus: true
+      },
+      {
+        label: 'Password',
+        field: 'password',
+        type: 'password',
+        placeholder: 'Enter password',
+        iconLeft: 'fas fa-lock',
+        autocomplete: 'current-password'
       }
     ]
   }


### PR DESCRIPTION
Follow-up to #475 — the `<form>` mode had JSDoc + a play-function test story, but was missing from the two user-facing docs surfaces:

- **`forms/README.md`** — new *Form Mode* section documenting `options.form`, the visually-hidden submit, and `onSubmit({ e, inputs, fields })`, with a login example.
- **`renderForm.stories.ts`** — threaded the `options` arg through the shared render (undefined → unchanged `<div>` for every existing story) and added a **`FormMode` autodocs demo** so the capability is visible in Storybook. Extracted the now-thrice-used `fa-envelope` literal to a constant to keep **zero lint warnings**.

Verification: full `pnpm lint` clean (0 warnings), `pnpm build` clean, `test-storybook` — 14 tests across both renderForm story files pass in chromium (3 form-mode play tests + 11 demo smoke tests incl. the new FormMode). Joins release 3.10.0 (#474).