### PR TITLE
feat(schedule-page): reserved schedule-cell kind for shared facilities

### DIFF
--- a/src/components/schedule-page/__tests__/scheduleGridCell.test.ts
+++ b/src/components/schedule-page/__tests__/scheduleGridCell.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, it, expect } from 'vitest';
+
+import { buildScheduleGridCell } from '../ui/scheduleGridCell';
+
+/**
+ * Reserved cell — a court slot taken by another facility-sharing tournament the viewer can't author.
+ * Opaque + read-only: shows "Reserved" plus whatever slim label the consumer passes, never matchUp
+ * detail. Takes precedence over a matchUpId (a reserved slot is not the viewer's own matchUp).
+ */
+describe('buildScheduleGridCell — reserved cell', () => {
+  it('renders a read-only reserved cell with the slim projection label', () => {
+    const el = buildScheduleGridCell({
+      matchUpId: '',
+      isReserved: true,
+      reservation: { tournamentName: 'City Open', scheduledTime: '14:00' },
+    });
+
+    expect(el.classList.contains('spl-cell--reserved')).toBe(true);
+    expect(el.dataset.reserved).toBe('true');
+    expect(el.textContent).toContain('Reserved');
+    expect(el.querySelector('.spl-grid-cell__reserved-name')?.textContent).toBe('City Open');
+    expect(el.querySelector('.spl-grid-cell__reserved-time')?.textContent).toBe('14:00');
+  });
+
+  it('is opaque — renders no matchUp/participant content even if a matchUpId is present', () => {
+    const el = buildScheduleGridCell({
+      matchUpId: 'M1',
+      isReserved: true,
+      sides: [{ participantName: 'Should Not Render' }] as any,
+    });
+
+    expect(el.classList.contains('spl-cell--reserved')).toBe(true);
+    expect(el.textContent).not.toContain('Should Not Render');
+  });
+
+  it('falls back to schedule.scheduledTime and omits the name when reservation label is absent', () => {
+    const el = buildScheduleGridCell({
+      matchUpId: '',
+      isReserved: true,
+      schedule: { scheduledTime: '09:30' },
+    });
+
+    expect(el.textContent).toContain('Reserved');
+    expect(el.textContent).toContain('09:30');
+    expect(el.querySelector('.spl-grid-cell__reserved-name')).toBeNull();
+  });
+});

--- a/src/components/schedule-page/types.ts
+++ b/src/components/schedule-page/types.ts
@@ -366,4 +366,18 @@ export interface ScheduleCellData {
      */
     registrations?: string[];
   };
+
+  /**
+   * Reserved cell (alternative to matchUp) — a court slot occupied by ANOTHER, facility-sharing
+   * tournament that the viewer does not author. Read-only and opaque: it carries no matchUp/participant
+   * detail, only the slim information the consumer chooses to surface from a schedule projection. The
+   * consumer renders it non-interactive (no drag/move) — the widget only handles its appearance.
+   */
+  isReserved?: boolean;
+  reservation?: {
+    /** Display label for the occupying tournament (e.g. its name), pre-formatted by the consumer. */
+    tournamentName?: string;
+    /** Optional scheduled time to show on the cell. */
+    scheduledTime?: string;
+  };
 }

--- a/src/components/schedule-page/ui/schedule-grid-cell.css
+++ b/src/components/schedule-page/ui/schedule-grid-cell.css
@@ -402,6 +402,54 @@
   white-space: nowrap;
 }
 
+/* ── Reserved Cell ──────────────────────────────────────── */
+/* A court slot taken by another facility-sharing tournament the viewer can't
+   author. Muted diagonal wash distinguishes it from own matchUp cells and from
+   BLOCKED/PRACTICE bookings; read-only (cursor:default, no drag affordance). */
+
+.spl-cell--reserved {
+  background: repeating-linear-gradient(
+    45deg,
+    var(--sp-card-bg),
+    var(--sp-card-bg) 5px,
+    var(--sp-border) 5px,
+    var(--sp-border) 10px
+  );
+  cursor: default;
+  opacity: 0.85;
+}
+
+.spl-grid-cell__reserved-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+}
+
+.spl-grid-cell__reserved-type {
+  font-weight: 700;
+  color: var(--sp-muted);
+  text-transform: uppercase;
+  font-size: 0.625rem;
+  letter-spacing: 0.04em;
+}
+
+.spl-grid-cell__reserved-name {
+  font-size: 0.6875rem;
+  color: var(--sp-muted);
+  text-align: center;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.spl-grid-cell__reserved-time {
+  font-size: 0.625rem;
+  color: var(--sp-muted);
+}
+
 /* ── Empty Cell ─────────────────────────────────────────── */
 
 .spl-cell--empty {

--- a/src/components/schedule-page/ui/scheduleGridCell.ts
+++ b/src/components/schedule-page/ui/scheduleGridCell.ts
@@ -41,8 +41,51 @@ export function buildScheduleGridCell(data: ScheduleCellData, config?: ScheduleC
   const cfg = config ?? DEFAULT_SCHEDULE_CELL_CONFIG;
 
   if (data.isBlocked) return buildBlockedCell(data);
+  if (data.isReserved) return buildReservedCell(data);
   if (data.matchUpId) return buildMatchUpCell(data, cfg);
   return buildEmptyCell();
+}
+
+// ============================================================================
+// Reserved Cell
+// ============================================================================
+
+/**
+ * A court slot taken by another facility-sharing tournament the viewer can't author. Opaque and
+ * read-only — shows only "Reserved" plus whatever slim label the consumer passes (tournament name,
+ * time). Never renders participants/scores. The consumer is responsible for NOT wiring drag/move on it.
+ */
+function buildReservedCell(data: ScheduleCellData): HTMLElement {
+  const cell = document.createElement('div');
+  cell.className = 'spl-grid-cell spl-cell--reserved';
+  cell.dataset.reserved = 'true';
+
+  const label = document.createElement('div');
+  label.className = 'spl-grid-cell__reserved-label';
+
+  const typeEl = document.createElement('div');
+  typeEl.className = 'spl-grid-cell__reserved-type';
+  typeEl.textContent = 'Reserved';
+  label.appendChild(typeEl);
+
+  const name = data.reservation?.tournamentName;
+  if (name) {
+    const nameEl = document.createElement('div');
+    nameEl.className = 'spl-grid-cell__reserved-name';
+    nameEl.textContent = name;
+    label.appendChild(nameEl);
+  }
+
+  const time = data.reservation?.scheduledTime ?? data.schedule?.scheduledTime;
+  if (time) {
+    const timeEl = document.createElement('div');
+    timeEl.className = 'spl-grid-cell__reserved-time';
+    timeEl.textContent = time;
+    label.appendChild(timeEl);
+  }
+
+  cell.appendChild(label);
+  return cell;
 }
 
 // ============================================================================

--- a/src/stories/schedule-page/ScheduleGridCell.stories.ts
+++ b/src/stories/schedule-page/ScheduleGridCell.stories.ts
@@ -545,6 +545,31 @@ export const BlockedCells = {
 };
 
 // ============================================================================
+// ReservedCells — a court slot taken by another facility-sharing tournament
+// ============================================================================
+
+export const ReservedCells = {
+  name: 'Reserved (facility-sharing)',
+  render: () => {
+    const cells = [
+      labeledCell(
+        { matchUpId: '', isReserved: true, reservation: { tournamentName: 'City Open', scheduledTime: '14:00' } },
+        'Name + time',
+      ),
+      labeledCell(
+        { matchUpId: '', isReserved: true, reservation: { tournamentName: 'Regional U16 Championships' } },
+        'Long name (ellipsis)',
+      ),
+      labeledCell({ matchUpId: '', isReserved: true }, 'Bare'),
+    ];
+    return gridLayout(
+      cells,
+      'Reserved — court taken by another facility-sharing tournament (opaque, read-only; consumer wires no drag)',
+    );
+  },
+};
+
+// ============================================================================
 // PracticeWithRegistrations — PRACTICE booking + per-window participant list
 // ============================================================================
 


### PR DESCRIPTION
## What
Adds a **reserved** schedule-cell kind to `buildScheduleGridCell` for shared-facility scheduling: a court slot taken by another facility-sharing tournament the viewer can't author.

- `isReserved` branch (before `matchUpId` — a reserved slot is not the viewer's own matchUp) → `buildReservedCell`
- Opaque + read-only: renders "Reserved" + an optional slim label (tournament name / time), **never** participant/matchUp detail; consumer wires no drag
- Distinct muted diagonal styling via `--sp-*` tokens (light + dark), separate from BLOCKED/PRACTICE
- `ScheduleCellData` gains `isReserved` + `reservation`

## Tests / stories
- New `scheduleGridCell` reserved-cell tests (happy-dom); Reserved story variant
- **1487 tests, lint 0, tsc 0**

## Ecosystem
First of a 3-repo chain (reserved cells for shared facilities). **Merge this first, then publish/bump** — TMX consumes the `isReserved` type. Paired with TMX #(shared-facility-reserved-cells) and CFS #(schedule-projection-coordination-view).